### PR TITLE
Allow each subsite to configure sorting the LMS dashboard by course_id ascending.

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -643,6 +643,10 @@ def dashboard(request):
     activation_email_support_link = configuration_helpers.get_value(
         'ACTIVATION_EMAIL_SUPPORT_LINK', settings.ACTIVATION_EMAIL_SUPPORT_LINK
     ) or settings.SUPPORT_SITE_LINK
+    dashboard_sort_by_course_id_ascending = configuration_helpers.get_value(
+        'DASHBOARD_SORT_BY_COURSE_ID_ASCENDING',
+        settings.FEATURES.get('DASHBOARD_SORT_BY_COURSE_ID_ASCENDING', False)
+    )
 
     # Let's filter out any courses in an "org" that has been declared to be
     # in a configuration
@@ -664,8 +668,13 @@ def dashboard(request):
     # understanding of usage patterns on prod.
     monitoring_utils.accumulate('num_courses', len(course_enrollments))
 
-    # sort the enrollment pairs by the enrollment date
-    course_enrollments.sort(key=lambda x: x.created, reverse=True)
+    # Sort the course order displayed to the end user.
+    if dashboard_sort_by_course_id_ascending:
+        # sort the enrollment pairs by the course_id ascending
+        course_enrollments.sort(key=lambda x: x.course_id, reverse=False)
+    else:
+        # sort the enrollment pairs by the enrollment date
+        course_enrollments.sort(key=lambda x: x.created, reverse=True)
 
     # Retrieve the course modes for each course
     enrolled_course_ids = [enrollment.course_id for enrollment in course_enrollments]

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -401,6 +401,9 @@ FEATURES = {
     # Whether to check the "Notify users by email" checkbox in the batch enrollment form
     # in the instructor dashboard.
     'BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT': True,
+
+    # Defines whether or not the LMS dashboard courses are sorted by course_id ascending or not.
+    'DASHBOARD_SORT_BY_COURSE_ID_ASCENDING': False,
 }
 
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews


### PR DESCRIPTION
Set the `DASHBOARD_SORT_BY_COURSE_ID_ASCENDING` flag to true to enable sorting by course_id ascending.