### PR TITLE
Restrict print and download of textbook files through `pdfjs` viewer.

### DIFF
--- a/common/static/js/vendor/pdfjs/viewer.js
+++ b/common/static/js/vendor/pdfjs/viewer.js
@@ -639,7 +639,8 @@ Preferences._readFromStorage = function (prefObj) {
     // Also intercept Cmd/Ctrl + Shift + P in Chrome and Opera
     if (event.keyCode === 80/*P*/ && (event.ctrlKey || event.metaKey) &&
         !event.altKey && (!event.shiftKey || window.chrome || window.opera)) {
-      window.print();
+      // Disable printing with ctrl+p
+      // window.print();
       if (hasAttachEvent) {
         // Only attachEvent can cancel Ctrl + P dialog in IE <=10
         // attachEvent is gone in IE11, so the dialog will re-appear in IE11.
@@ -1732,10 +1733,10 @@ var SecondaryToolbar = {
     // Define the toolbar buttons.
     this.toggleButton = options.toggleButton;
     this.presentationModeButton = options.presentationModeButton;
-    this.openFile = options.openFile;
-    this.print = options.print;
-    this.download = options.download;
-    this.viewBookmark = options.viewBookmark;
+    // this.openFile = options.openFile;
+    // this.print = options.print;
+    // this.download = options.download;
+    // this.viewBookmark = options.viewBookmark;
     this.firstPage = options.firstPage;
     this.lastPage = options.lastPage;
     this.pageRotateCw = options.pageRotateCw;
@@ -1750,10 +1751,10 @@ var SecondaryToolbar = {
       // (except for toggleHandTool, hand_tool.js is responsible for it):
       { element: this.presentationModeButton,
         handler: this.presentationModeClick },
-      { element: this.openFile, handler: this.openFileClick },
-      { element: this.print, handler: this.printClick },
-      { element: this.download, handler: this.downloadClick },
-      { element: this.viewBookmark, handler: this.viewBookmarkClick },
+      // { element: this.openFile, handler: this.openFileClick },
+      // { element: this.print, handler: this.printClick },
+      // { element: this.download, handler: this.downloadClick },
+      // { element: this.viewBookmark, handler: this.viewBookmarkClick },
       { element: this.firstPage, handler: this.firstPageClick },
       { element: this.lastPage, handler: this.lastPageClick },
       { element: this.pageRotateCw, handler: this.pageRotateCwClick },
@@ -1776,24 +1777,24 @@ var SecondaryToolbar = {
     this.close();
   },
 
-  openFileClick: function secondaryToolbarOpenFileClick(evt) {
-    document.getElementById('fileInput').click();
-    this.close();
-  },
-
-  printClick: function secondaryToolbarPrintClick(evt) {
-    window.print();
-    this.close();
-  },
-
-  downloadClick: function secondaryToolbarDownloadClick(evt) {
-    PDFViewerApplication.download();
-    this.close();
-  },
-
-  viewBookmarkClick: function secondaryToolbarViewBookmarkClick(evt) {
-    this.close();
-  },
+  // openFileClick: function secondaryToolbarOpenFileClick(evt) {
+  //   document.getElementById('fileInput').click();
+  //   this.close();
+  // },
+  //
+  // printClick: function secondaryToolbarPrintClick(evt) {
+  //   window.print();
+  //   this.close();
+  // },
+  //
+  // downloadClick: function secondaryToolbarDownloadClick(evt) {
+  //   PDFViewerApplication.download();
+  //   this.close();
+  // },
+  //
+  // viewBookmarkClick: function secondaryToolbarViewBookmarkClick(evt) {
+  //   this.close();
+  // },
 
   firstPageClick: function secondaryToolbarFirstPageClick(evt) {
     PDFViewerApplication.page = 1;
@@ -5314,9 +5315,10 @@ var PDFViewerApplication = {
           for (var i = 0, ii = javaScript.length; i < ii; i++) {
             var js = javaScript[i];
             if (js && regex.test(js)) {
-              setTimeout(function() {
-                window.print();
-              });
+              // Disable Printing with CTRL + P
+              // setTimeout(function() {
+              //   window.print();
+              // });
               return;
             }
           }
@@ -6187,8 +6189,8 @@ function webViewerInitialized() {
   document.body.appendChild(fileInput);
 
   if (!window.File || !window.FileReader || !window.FileList || !window.Blob) {
-    document.getElementById('openFile').setAttribute('hidden', 'true');
-    document.getElementById('secondaryOpenFile').setAttribute('hidden', 'true');
+    // document.getElementById('openFile').setAttribute('hidden', 'true');
+    // document.getElementById('secondaryOpenFile').setAttribute('hidden', 'true');
   } else {
     document.getElementById('fileInput').value = null;
   }
@@ -6258,10 +6260,10 @@ function webViewerInitialized() {
 
   mozL10n.setLanguage(locale);
 
-  if (!PDFViewerApplication.supportsPrinting) {
-    document.getElementById('print').classList.add('hidden');
-    document.getElementById('secondaryPrint').classList.add('hidden');
-  }
+  // if (!PDFViewerApplication.supportsPrinting) {
+  //   document.getElementById('print').classList.add('hidden');
+  //   document.getElementById('secondaryPrint').classList.add('hidden');
+  // }
 
   if (!PDFViewerApplication.supportsFullscreen) {
     document.getElementById('presentationMode').classList.add('hidden');
@@ -6357,14 +6359,14 @@ function webViewerInitialized() {
   document.getElementById('presentationMode').addEventListener('click',
     SecondaryToolbar.presentationModeClick.bind(SecondaryToolbar));
 
-  document.getElementById('openFile').addEventListener('click',
-    SecondaryToolbar.openFileClick.bind(SecondaryToolbar));
-
-  document.getElementById('print').addEventListener('click',
-    SecondaryToolbar.printClick.bind(SecondaryToolbar));
-
-  document.getElementById('download').addEventListener('click',
-    SecondaryToolbar.downloadClick.bind(SecondaryToolbar));
+  // document.getElementById('openFile').addEventListener('click',
+  //   SecondaryToolbar.openFileClick.bind(SecondaryToolbar));
+  //
+  // document.getElementById('print').addEventListener('click',
+  //   SecondaryToolbar.printClick.bind(SecondaryToolbar));
+  //
+  // document.getElementById('download').addEventListener('click',
+  //   SecondaryToolbar.downloadClick.bind(SecondaryToolbar));
 
 
   if (file && file.lastIndexOf('file:', 0) === 0) {
@@ -6450,8 +6452,8 @@ window.addEventListener('updateviewarea', function () {
     });
   });
   var href = PDFViewerApplication.getAnchorUrl(location.pdfOpenParams);
-  document.getElementById('viewBookmark').href = href;
-  document.getElementById('secondaryViewBookmark').href = href;
+  // document.getElementById('viewBookmark').href = href;
+  // document.getElementById('secondaryViewBookmark').href = href;
 
   // Update the current bookmark in the browsing history.
   PDFHistory.updateCurrentBookmark(location.pdfOpenParams, location.pageNumber);
@@ -6512,11 +6514,11 @@ window.addEventListener('change', function webViewerChange(evt) {
   PDFViewerApplication.setTitleUsingUrl(file.name);
 
   // URL does not reflect proper document location - hiding some icons.
-  document.getElementById('viewBookmark').setAttribute('hidden', 'true');
-  document.getElementById('secondaryViewBookmark').
+  // document.getElementById('viewBookmark').setAttribute('hidden', 'true');
+  // document.getElementById('secondaryViewBookmark').
     setAttribute('hidden', 'true');
-  document.getElementById('download').setAttribute('hidden', 'true');
-  document.getElementById('secondaryDownload').setAttribute('hidden', 'true');
+  // document.getElementById('download').setAttribute('hidden', 'true');
+  // document.getElementById('secondaryDownload').setAttribute('hidden', 'true');
 }, true);
 
 function selectScaleOption(value) {

--- a/lms/templates/pdf_viewer.html
+++ b/lms/templates/pdf_viewer.html
@@ -108,22 +108,6 @@ http://sourceforge.net/adobe/cmap/wiki/License/
               <span data-l10n-id="presentation_mode_label">Presentation Mode</span>
             </button>
 
-            <button id="secondaryOpenFile" class="secondaryToolbarButton openFile visibleLargeView" title="Open File" data-l10n-id="open_file">
-              <span data-l10n-id="open_file_label">Open</span>
-            </button>
-
-            <button id="secondaryPrint" class="secondaryToolbarButton print visibleMediumView" title="Print" data-l10n-id="print">
-              <span data-l10n-id="print_label">Print</span>
-            </button>
-
-            <button id="secondaryDownload" class="secondaryToolbarButton download visibleMediumView" title="Download" data-l10n-id="download">
-              <span data-l10n-id="download_label">Download</span>
-            </button>
-
-            <a href="#" id="secondaryViewBookmark" class="secondaryToolbarButton bookmark visibleSmallView" title="Current view (copy or open in new window)" data-l10n-id="bookmark">
-              <span data-l10n-id="bookmark_label">Current View</span>
-          </a>
-
             <div class="horizontalToolbarSeparator visibleLargeView"></div>
 
             <button id="firstPage" class="secondaryToolbarButton firstPage" title="Go to First Page" data-l10n-id="first_page">
@@ -184,22 +168,6 @@ http://sourceforge.net/adobe/cmap/wiki/License/
                 <button id="presentationMode" class="toolbarButton presentationMode hiddenLargeView" title="Switch to Presentation Mode" data-l10n-id="presentation_mode">
                   <span data-l10n-id="presentation_mode_label">Presentation Mode</span>
                 </button>
-
-                <button id="openFile" class="toolbarButton openFile hiddenLargeView" title="Open File" data-l10n-id="open_file">
-                  <span data-l10n-id="open_file_label">Open</span>
-                </button>
-
-                <button id="print" class="toolbarButton print hiddenMediumView" title="Print" data-l10n-id="print">
-                  <span data-l10n-id="print_label">Print</span>
-                </button>
-
-                <button id="download" class="toolbarButton download hiddenMediumView" title="Download" data-l10n-id="download">
-                  <span data-l10n-id="download_label">Download</span>
-                </button>
-                <!-- <div class="toolbarButtonSpacer"></div> -->
-                <a href="#" id="viewBookmark" class="toolbarButton bookmark hiddenSmallView" title="Current view (copy or open in new window)" data-l10n-id="bookmark">
-                  <span data-l10n-id="bookmark_label">Current View</span>
-                </a>
 
                 <div class="verticalToolbarSeparator hiddenSmallView"></div>
                 


### PR DESCRIPTION
Todo: Need to add an NGINX rule to also prevent viewing of PDF when HTTP Request Referrer is not coming from LMS static/js/vendor/pdfjs/pdf.worker.js address. Since the learner could inspect (Chrome > Inspector Tools > Network > XHR) and open the PDF in separate tab then download directly.