### PR TITLE
Fix BadgeClass `slug` issue by creating a temporary unique id within the course complete event.

### DIFF
--- a/lms/djangoapps/badges/events/course_complete.py
+++ b/lms/djangoapps/badges/events/course_complete.py
@@ -68,6 +68,7 @@ def get_completion_badge(course_id, user):
     if not course.issue_badges:
         return None
     return BadgeClass.get_badge_class(
+        issuing_component='openedx__course',
         criteria=criteria(course_id),
         description=badge_description(course, mode),
         course_id=course_id,

--- a/lms/djangoapps/badges/models.py
+++ b/lms/djangoapps/badges/models.py
@@ -1,6 +1,7 @@
 """
 Database models for the badges app
 """
+import hashlib
 from importlib import import_module
 
 from config_models.models import ConfigurationModel
@@ -8,6 +9,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.template.defaultfilters import slugify
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext_noop
 from jsonfield import JSONField
@@ -65,6 +67,19 @@ class BadgeClass(models.Model):
         )
 
     @classmethod
+    def get_legacy_course_slug(cls, course_key, mode):
+        """
+        Legacy: Not to be used as a model for constructing badge slugs. Included for compatibility with the original badge
+        type, awarded on course completion.
+         Slug ought to be deterministic and limited in size so it's not too big for Badgr.
+         Badgr's max slug length is 255.
+        """
+        # Seven digits should be enough to realistically avoid collisions. That's what git services use.
+        digest = hashlib.sha256(u"{}{}".format(unicode(course_key), unicode(mode))).hexdigest()[:7]
+        base_slug = slugify(unicode(course_key) + u'_{}_'.format(mode))[:248]
+        return base_slug + digest
+
+    @classmethod
     def get_badge_class(
             cls, slug=None, issuing_component=None, display_name=None, description=None, criteria=None, image_file_handle=None,
             mode='', course_id=None, create=True
@@ -94,7 +109,7 @@ class BadgeClass(models.Model):
             if not create:
                 return None
         badge_class = cls(
-            slug=slug,
+            slug=cls.get_legacy_course_slug(course_key=course_id, mode=mode),
             issuing_component=issuing_component,
             display_name=display_name,
             course_id=course_id,
@@ -102,7 +117,7 @@ class BadgeClass(models.Model):
             description=description,
             criteria=criteria,
         )
-        badge_class.image.save(image_file_handle.name, image_file_handle)
+        badge_class.image.save(image_file_handle.name, image_file_handle, save=False)
         badge_class.full_clean()
         badge_class.save()
         return badge_class

--- a/lms/djangoapps/badges/utils.py
+++ b/lms/djangoapps/badges/utils.py
@@ -2,14 +2,14 @@
 Utility functions used by the badging app.
 """
 from django.conf import settings
-
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 def site_prefix():
     """
     Get the prefix for the site URL-- protocol and server name.
     """
     scheme = u"https" if settings.HTTPS == "on" else u"http"
-    return u'{}://{}'.format(scheme, settings.SITE_NAME)
+    return u'{}://{}'.format(scheme, configuration_helpers.get_value("SITE_NAME", settings.SITE_NAME))
 
 
 def requires_badges_enabled(function):


### PR DESCRIPTION
Since the BadgeClass slug will be replaced by a unique slug from the Badgr.io service on save to the BadgeClass model instance needs to be unique on course complete event generation. This allows the course complete BadgeClass to be created with unique slug (course_id + mode) and course mode as defined in the clean routine for the model.  

- Minor fix with the evidence url pulling SITE_NAME  being site configuration to help with rendering of subsite specific certificate template. 