### PR TITLE
Fix issue where `Evidence URL` domain shows correct org URL for given subsite.

### DIFF
--- a/lms/djangoapps/badges/events/course_complete.py
+++ b/lms/djangoapps/badges/events/course_complete.py
@@ -40,7 +40,7 @@ def evidence_url(user_id, course_key):
     Generates a URL to the user's Certificate HTML view, along with a GET variable that will signal the evidence visit
     event.
     """
-    return site_prefix() + reverse(
+    return site_prefix(course_key.org) + reverse(
         'certificates:html_view', kwargs={'user_id': user_id, 'course_id': unicode(course_key)}) + '?evidence_visit=1'
 
 
@@ -49,7 +49,7 @@ def criteria(course_key):
     Constructs the 'criteria' URL from the course about page.
     """
     about_path = reverse('about_course', kwargs={'course_id': unicode(course_key)})
-    return u'{}{}'.format(site_prefix(), about_path)
+    return u'{}{}'.format(site_prefix(course_key.org), about_path)
 
 
 def get_completion_badge(course_id, user):

--- a/lms/djangoapps/badges/utils.py
+++ b/lms/djangoapps/badges/utils.py
@@ -4,12 +4,13 @@ Utility functions used by the badging app.
 from django.conf import settings
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
-def site_prefix():
+
+def site_prefix(org):
     """
     Get the prefix for the site URL-- protocol and server name.
     """
     scheme = u"https" if settings.HTTPS == "on" else u"http"
-    return u'{}://{}'.format(scheme, configuration_helpers.get_value("SITE_NAME", settings.SITE_NAME))
+    return u'{}://{}'.format(scheme, configuration_helpers.get_value_for_org(org, "SITE_NAME", settings.SITE_NAME))
 
 
 def requires_badges_enabled(function):


### PR DESCRIPTION
In a AWS (production) environment the `Evidence URL` kept showing the default site domain even for a subsite. This fixes the issue since `configuration_helpers.get_value` was always was checking for the `openedx.core.djangoapps.theming.helpers.py:get_current_site()` which was turning up Empty since production uses Celery task (`lms_high_mem_1`) to regenerate the certificate.