### PR TITLE
Fix `SameSite` cookie issue for LTI Provider calls within external LMS platforms (e.g. Canvas, Blackboard)

### DIFF
--- a/common/djangoapps/student/cookies.py
+++ b/common/djangoapps/student/cookies.py
@@ -86,7 +86,7 @@ def set_logged_in_cookies(request, response, user):
     response.set_cookie(
         settings.EDXMKTG_LOGGED_IN_COOKIE_NAME.encode('utf-8'),
         'true',
-        secure=None,
+        secure=request.is_secure(),
         **cookie_settings
     )
 

--- a/common/djangoapps/student/views/login.py
+++ b/common/djangoapps/student/views/login.py
@@ -721,7 +721,7 @@ def auto_auth(request):
             'user_id': user.id,  # pylint: disable=no-member
             'anonymous_id': anonymous_id_for_user(user, None),
         })
-    response.set_cookie('csrftoken', csrf(request)['csrf_token'])
+    response.set_cookie('csrftoken', csrf(request)['csrf_token'], secure=request.is_secure())
     return response
 
 

--- a/lms/djangoapps/email_marketing/signals.py
+++ b/lms/djangoapps/email_marketing/signals.py
@@ -116,6 +116,7 @@ def add_email_marketing_cookies(sender, response=None, user=None,
             max_age=365 * 24 * 60 * 60,  # set for 1 year
             domain=settings.SESSION_COOKIE_DOMAIN,
             path='/',
+            secure=request.is_secure()
         )
         log.info("sailthru_hid cookie:%s successfully retrieved for user %s", cookie, user.email)
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1231,6 +1231,10 @@ CREDIT_NOTIFICATION_CACHE_TIMEOUT = 5 * 60 * 60
 ################################# Middleware ###################################
 
 MIDDLEWARE_CLASSES = [
+    # Avoid issue with https://blog.heroku.com/chrome-changes-samesite-cookie
+    # Override was found here https://github.com/django/django/pull/11894
+    'django_cookies_samesite.middleware.CookiesSameSite',
+
     'crum.CurrentRequestUserMiddleware',
 
     'openedx.core.djangoapps.request_cache.middleware.RequestCache',

--- a/openedx/core/djangoapps/lang_pref/middleware.py
+++ b/openedx/core/djangoapps/lang_pref/middleware.py
@@ -77,6 +77,7 @@ class LanguagePreferenceMiddleware(object):
                     value=user_pref,
                     domain=settings.SESSION_COOKIE_DOMAIN,
                     max_age=COOKIE_DURATION,
+                    secure=request.is_secure()
                 )
             else:
                 response.delete_cookie(

--- a/openedx/core/djangoapps/lang_pref/views.py
+++ b/openedx/core/djangoapps/lang_pref/views.py
@@ -27,6 +27,7 @@ def update_session_language(request):
             settings.LANGUAGE_COOKIE,
             language,
             domain=settings.SESSION_COOKIE_DOMAIN,
-            max_age=COOKIE_DURATION
+            max_age=COOKIE_DURATION,
+            secure=request.is_secure(),
         )
     return response

--- a/openedx/features/learner_profile/views/learner_profile.py
+++ b/openedx/features/learner_profile/views/learner_profile.py
@@ -72,7 +72,7 @@ def learner_profile(request, username):
         )
 
         if message_viewed:
-            response.set_cookie('profile-message-viewed', 'True')
+            response.set_cookie('profile-message-viewed', 'True', secure=request.is_secure())
         return response
     except (UserNotAuthorized, UserNotFound, ObjectDoesNotExist):
         raise Http404

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -36,6 +36,7 @@ defusedxml==0.4.1                   # XML bomb protection for common XML parsers
 Django==1.11.15                     # Web application framework
 django-babel-underscore             # underscore template extractor for django-babel (internationalization utilities)
 django-config-models==0.1.8         # Configuration models for Django allowing config management with auditing
+django-cookies-samesite==0.5.1      # Middleware that fixes SameSite cookie issues for LTI Provider
 django-cors-headers==2.1.0          # Used to allow to configure CORS headers for cross-domain requests
 django-countries==4.6.1             # Country data for Django forms and model fields
 django-crum                         # Middleware that stores the current request and user in thread local storage

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -72,6 +72,7 @@ django-babel==0.6.2       # via django-babel-underscore
 django-braces==1.13.0     # via django-oauth-toolkit
 django-classy-tags==0.8.0  # via django-sekizai
 django-config-models==0.1.8
+django-cookies-samesite==0.5.1
 django-cors-headers==2.1.0
 django-countries==4.6.1
 django-crum==0.7.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -91,6 +91,7 @@ django-babel==0.6.2
 django-braces==1.13.0
 django-classy-tags==0.8.0
 django-config-models==0.1.8
+django-cookies-samesite==0.5.1
 django-cors-headers==2.1.0
 django-countries==4.6.1
 django-crum==0.7.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -88,6 +88,7 @@ django-babel==0.6.2
 django-braces==1.13.0
 django-classy-tags==0.8.0
 django-config-models==0.1.8
+django-cookies-samesite==0.5.1
 django-cors-headers==2.1.0
 django-countries==4.6.1
 django-crum==0.7.2


### PR DESCRIPTION
There was an issue where external LMS system (e.g. Canvas, Blackboard) that used Open edX LTI Provider calls had cookies blocked. This update fixes this issue by defining third-party cookies to have attributes of `Secure=True` and `SameSite=None`. 

Details here: https://discuss.openedx.org/t/lti-xblock-and-samesite/759/5