### PR TITLE
Merged changes in for redirecting from `dashboard` page to `resume course` for `ENABLE_REDIRECT_TO_RESUME_COURSE_ON_COURSE_INFO` Site Configuration flag for Ironwood release.

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -444,6 +444,11 @@ def course_info(request, course_id):
         if SelfPacedConfiguration.current().enable_course_home_improvements:
             context['resume_course_url'] = get_last_accessed_courseware(course, request, user)
 
+        # Redirect to Resume Course url if site configuration flag is enabled.
+        if context['resume_course_url'] and configuration_helpers.get_value(
+                'ENABLE_REDIRECT_TO_RESUME_COURSE_ON_COURSE_INFO', False):
+            return redirect(context['resume_course_url'])
+
         if not check_course_open_for_learner(user, course):
             # Disable student view button if user is staff and
             # course is not yet visible to students.

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -25,6 +25,7 @@ from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from lms.djangoapps.courseware.views.views import CourseTabView
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.core.djangoapps.util.maintenance_banner import add_maintenance_banner
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.features.course_experience.course_tools import CourseToolsPluginManager
 from openedx.features.course_duration_limits.access import generate_course_expired_fragment
 from student.models import CourseEnrollment
@@ -220,5 +221,11 @@ class CourseHomeFragmentView(EdxFragmentView):
             'upgrade_price': upgrade_price,
             'upgrade_url': upgrade_url,
         }
+
+        # Redirect to Resume Course url if site configuration flag is enabled.
+        if context['resume_course_url'] and configuration_helpers.get_value(
+                'ENABLE_REDIRECT_TO_RESUME_COURSE_ON_COURSE_INFO', False):
+            raise CourseAccessRedirect(context['resume_course_url'])
+
         html = render_to_string('course_experience/course-home-fragment.html', context)
         return Fragment(html)


### PR DESCRIPTION
The subsite that uses this is Caregiver only.