### PR TITLE
Using webpack to install Owl Carousel 2 (2.3.4) bundle using NPM going forward is recommended way to install third-party Javascript libraries for edX for Ironwood release.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -735,6 +735,8 @@ PIPELINE_CSS = {
             'css/vendor/jquery.qtip.min.css',
             'js/vendor/markitup/skins/simple/style.css',
             'js/vendor/markitup/sets/wiki/style.css',
+            'common/css/vendor/owl.carousel.css',
+            'common/css/vendor/owl.theme.default.css',
         ],
         'output_filename': 'css/cms-style-vendor.css',
     },
@@ -806,6 +808,9 @@ base_vendor_js = [
     'common/js/vendor/underscore.string.js',
     'common/js/vendor/backbone.js',
     'js/vendor/URI.min.js',
+
+    # Load Owl Carousel
+    'common/js/vendor/owl.carousel.js',
 
     # Make some edX UI Toolkit utilities available in the global "edx" namespace
     'edx-ui-toolkit/js/utils/global-loader.js',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1396,6 +1396,9 @@ base_vendor_js = [
     'common/js/vendor/underscore.string.js',
     'common/js/vendor/picturefill.js',
 
+    # Load Owl Carousel
+    'common/js/vendor/owl.carousel.js',
+
     # Make some edX UI Toolkit utilities available in the global "edx" namespace
     'edx-ui-toolkit/js/utils/global-loader.js',
     'edx-ui-toolkit/js/utils/string-utils.js',
@@ -1517,6 +1520,8 @@ PIPELINE_CSS = {
         'source_filenames': [
             'css/vendor/font-awesome.css',
             'css/vendor/jquery.qtip.min.css',
+            'common/css/vendor/owl.carousel.css',
+            'common/css/vendor/owl.theme.default.css',
         ],
         'output_filename': 'css/lms-style-vendor.css',
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9142,6 +9142,14 @@
         "os-tmpdir": "1.0.2"
       }
     },
+    "owl.carousel": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/owl.carousel/-/owl.carousel-2.3.4.tgz",
+      "integrity": "sha512-JaDss9+feAvEW8KZppPSpllfposEzQiW+Ytt/Xm5t/3CTJ7YVmkh6RkWixoA2yXk2boIwedYxOvrrppIGzru9A==",
+      "requires": {
+        "jquery": "2.2.4"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "moment": "2.18.1",
     "moment-timezone": "0.5.14",
     "node-sass": "4.7.2",
+    "owl.carousel": "2.3.4",
     "picturefill": "3.0.2",
     "popper.js": "1.12.9",
     "prop-types": "15.6.0",

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -60,6 +60,7 @@ NPM_INSTALLED_LIBRARIES = [
     'jquery/dist/jquery.js',
     'moment-timezone/builds/moment-timezone-with-data.js',
     'moment/min/moment-with-locales.js',
+    'owl.carousel/dist/',
     'picturefill/dist/picturefill.js',
     'requirejs/require.js',
     'underscore.string/dist/underscore.string.js',


### PR DESCRIPTION
Installed third-party Javascript library using `paver install_prereqs` from the lms-shell on docker_devstack. This will also be called on `update_assets`.

References
https://openedx.atlassian.net/wiki/spaces/FEDX/pages/67338650/How+to+add+a+new+third+party+JavaScript+library+to+LMS+or+Studio
https://open-edx-proposals.readthedocs.io/en/latest/oep-0011-bp-FED-technology.html
https://www.npmjs.com/package/owl.carousel
https://webpack.js.org/guides/getting-started/#npm-scripts