### PR TITLE
Restrict LMS ebook from Printing for Ironwood release.

### DIFF
--- a/common/static/js/vendor/pdfjs/viewer.js
+++ b/common/static/js/vendor/pdfjs/viewer.js
@@ -639,7 +639,8 @@ Preferences._readFromStorage = function (prefObj) {
     // Also intercept Cmd/Ctrl + Shift + P in Chrome and Opera
     if (event.keyCode === 80/*P*/ && (event.ctrlKey || event.metaKey) &&
         !event.altKey && (!event.shiftKey || window.chrome || window.opera)) {
-      window.print();
+      // Disable printing with ctrl+p
+      // window.print();
       if (hasAttachEvent) {
         // Only attachEvent can cancel Ctrl + P dialog in IE <=10
         // attachEvent is gone in IE11, so the dialog will re-appear in IE11.
@@ -1732,10 +1733,10 @@ var SecondaryToolbar = {
     // Define the toolbar buttons.
     this.toggleButton = options.toggleButton;
     this.presentationModeButton = options.presentationModeButton;
-    this.openFile = options.openFile;
-    this.print = options.print;
-    this.download = options.download;
-    this.viewBookmark = options.viewBookmark;
+    //this.openFile = options.openFile;
+    //this.print = options.print;
+    //this.download = options.download;
+    //this.viewBookmark = options.viewBookmark;
     this.firstPage = options.firstPage;
     this.lastPage = options.lastPage;
     this.pageRotateCw = options.pageRotateCw;
@@ -1750,10 +1751,10 @@ var SecondaryToolbar = {
       // (except for toggleHandTool, hand_tool.js is responsible for it):
       { element: this.presentationModeButton,
         handler: this.presentationModeClick },
-      { element: this.openFile, handler: this.openFileClick },
-      { element: this.print, handler: this.printClick },
-      { element: this.download, handler: this.downloadClick },
-      { element: this.viewBookmark, handler: this.viewBookmarkClick },
+      //{ element: this.openFile, handler: this.openFileClick },
+      //{ element: this.print, handler: this.printClick },
+      //{ element: this.download, handler: this.downloadClick },
+      //{ element: this.viewBookmark, handler: this.viewBookmarkClick },
       { element: this.firstPage, handler: this.firstPageClick },
       { element: this.lastPage, handler: this.lastPageClick },
       { element: this.pageRotateCw, handler: this.pageRotateCwClick },
@@ -1776,7 +1777,7 @@ var SecondaryToolbar = {
     this.close();
   },
 
-  openFileClick: function secondaryToolbarOpenFileClick(evt) {
+  /*openFileClick: function secondaryToolbarOpenFileClick(evt) {
     document.getElementById('fileInput').click();
     this.close();
   },
@@ -1793,7 +1794,7 @@ var SecondaryToolbar = {
 
   viewBookmarkClick: function secondaryToolbarViewBookmarkClick(evt) {
     this.close();
-  },
+  },*/
 
   firstPageClick: function secondaryToolbarFirstPageClick(evt) {
     PDFViewerApplication.page = 1;
@@ -4661,10 +4662,10 @@ var PDFViewerApplication = {
       toggleButton: document.getElementById('secondaryToolbarToggle'),
       presentationModeButton:
         document.getElementById('secondaryPresentationMode'),
-      openFile: document.getElementById('secondaryOpenFile'),
-      print: document.getElementById('secondaryPrint'),
-      download: document.getElementById('secondaryDownload'),
-      viewBookmark: document.getElementById('secondaryViewBookmark'),
+      //openFile: document.getElementById('secondaryOpenFile'),
+      //print: document.getElementById('secondaryPrint'),
+      //download: document.getElementById('secondaryDownload'),
+      //viewBookmark: document.getElementById('secondaryViewBookmark'),
       firstPage: document.getElementById('firstPage'),
       lastPage: document.getElementById('lastPage'),
       pageRotateCw: document.getElementById('pageRotateCw'),
@@ -5314,9 +5315,9 @@ var PDFViewerApplication = {
           for (var i = 0, ii = javaScript.length; i < ii; i++) {
             var js = javaScript[i];
             if (js && regex.test(js)) {
-              setTimeout(function() {
+              /*setTimeout(function() {
                 window.print();
-              });
+              });*/
               return;
             }
           }
@@ -6187,8 +6188,8 @@ function webViewerInitialized() {
   document.body.appendChild(fileInput);
 
   if (!window.File || !window.FileReader || !window.FileList || !window.Blob) {
-    document.getElementById('openFile').setAttribute('hidden', 'true');
-    document.getElementById('secondaryOpenFile').setAttribute('hidden', 'true');
+    //document.getElementById('openFile').setAttribute('hidden', 'true');
+    //document.getElementById('secondaryOpenFile').setAttribute('hidden', 'true');
   } else {
     document.getElementById('fileInput').value = null;
   }
@@ -6258,10 +6259,10 @@ function webViewerInitialized() {
 
   mozL10n.setLanguage(locale);
 
-  if (!PDFViewerApplication.supportsPrinting) {
+  /*if (!PDFViewerApplication.supportsPrinting) {
     document.getElementById('print').classList.add('hidden');
     document.getElementById('secondaryPrint').classList.add('hidden');
-  }
+  }*/
 
   if (!PDFViewerApplication.supportsFullscreen) {
     document.getElementById('presentationMode').classList.add('hidden');
@@ -6357,14 +6358,14 @@ function webViewerInitialized() {
   document.getElementById('presentationMode').addEventListener('click',
     SecondaryToolbar.presentationModeClick.bind(SecondaryToolbar));
 
-  document.getElementById('openFile').addEventListener('click',
+  /*document.getElementById('openFile').addEventListener('click',
     SecondaryToolbar.openFileClick.bind(SecondaryToolbar));
 
   document.getElementById('print').addEventListener('click',
     SecondaryToolbar.printClick.bind(SecondaryToolbar));
 
   document.getElementById('download').addEventListener('click',
-    SecondaryToolbar.downloadClick.bind(SecondaryToolbar));
+    SecondaryToolbar.downloadClick.bind(SecondaryToolbar));*/
 
 
   if (file && file.lastIndexOf('file:', 0) === 0) {
@@ -6450,8 +6451,8 @@ window.addEventListener('updateviewarea', function () {
     });
   });
   var href = PDFViewerApplication.getAnchorUrl(location.pdfOpenParams);
-  document.getElementById('viewBookmark').href = href;
-  document.getElementById('secondaryViewBookmark').href = href;
+  //document.getElementById('viewBookmark').href = href;
+  //document.getElementById('secondaryViewBookmark').href = href;
 
   // Update the current bookmark in the browsing history.
   PDFHistory.updateCurrentBookmark(location.pdfOpenParams, location.pageNumber);
@@ -6512,11 +6513,11 @@ window.addEventListener('change', function webViewerChange(evt) {
   PDFViewerApplication.setTitleUsingUrl(file.name);
 
   // URL does not reflect proper document location - hiding some icons.
-  document.getElementById('viewBookmark').setAttribute('hidden', 'true');
-  document.getElementById('secondaryViewBookmark').
+  //document.getElementById('viewBookmark').setAttribute('hidden', 'true');
+  //document.getElementById('secondaryViewBookmark').
     setAttribute('hidden', 'true');
-  document.getElementById('download').setAttribute('hidden', 'true');
-  document.getElementById('secondaryDownload').setAttribute('hidden', 'true');
+  //document.getElementById('download').setAttribute('hidden', 'true');
+  //document.getElementById('secondaryDownload').setAttribute('hidden', 'true');
 }, true);
 
 function selectScaleOption(value) {

--- a/lms/templates/pdf_viewer.html
+++ b/lms/templates/pdf_viewer.html
@@ -32,23 +32,23 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     <meta name="path_prefix" content="${EDX_ROOT_URL}">
     <title>${current_chapter['title'] if current_chapter else ''}</title>
 
-    <link rel="stylesheet" href="${static.url('/static/css/vendor/pdfjs/viewer.css')}"/>
+    <link rel="stylesheet" href="${static.url('css/vendor/pdfjs/viewer.css')}"/>
 
-    <script type="text/javascript" src="${static.url('/static/js/vendor/pdfjs/compatibility.js')}"></script>
+    <script type="text/javascript" src="${static.url('js/vendor/pdfjs/compatibility.js')}"></script>
 
     <!-- This snippet is used in production (included from viewer.html) -->
-    <link rel="resource" type="application/l10n" href="${static.url('/static/js/vendor/pdfjs/locale/locale.properties')}"/>
-    <script type="text/javascript" src="${static.url('/static/js/vendor/pdfjs/l10n.js')}"></script>
-    <script type="text/javascript" src="${static.url('/static/js/vendor/pdfjs/pdf.js')}"></script>
+    <link rel="resource" type="application/l10n" href="${static.url('js/vendor/pdfjs/locale/locale.properties')}"/>
+    <script type="text/javascript" src="${static.url('js/vendor/pdfjs/l10n.js')}"></script>
+    <script type="text/javascript" src="${static.url('js/vendor/pdfjs/pdf.js')}"></script>
 
     <script type="text/javascript">
-        PDFJS.imageResourcesPath = "${static.url('/static/css/vendor/pdfjs/images/') | n, js_escaped_string}";
-        PDFJS.workerSrc = "${static.url('/static/js/vendor/pdfjs/pdf.worker.js') | n, js_escaped_string}";
-        PDFJS.cMapUrl = "${static.url('/static/css/vendor/pdfjs/cmaps/') | n, js_escaped_string}";
+        PDFJS.imageResourcesPath = "${static.url('css/vendor/pdfjs/images/') | n, js_escaped_string}";
+        PDFJS.workerSrc = "${static.url('js/vendor/pdfjs/pdf.worker.js') | n, js_escaped_string}";
+        PDFJS.cMapUrl = "${static.url('css/vendor/pdfjs/cmaps/') | n, js_escaped_string}";
         PDF_URL = '${current_url | n, js_escaped_string}';
     </script>
 
-    <script ${static.url('/static/js/vendor/pdfjs/debugger.js')}></script>
+    <script ${static.url('js/vendor/pdfjs/debugger.js')}></script>
     
     <%static:js group='main_vendor'/>
     <%static:js group='application'/>
@@ -108,7 +108,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
               <span data-l10n-id="presentation_mode_label">Presentation Mode</span>
             </button>
 
-            <button id="secondaryOpenFile" class="secondaryToolbarButton openFile visibleLargeView" title="Open File" data-l10n-id="open_file">
+            <!-- <button id="secondaryOpenFile" class="secondaryToolbarButton openFile visibleLargeView" title="Open File" data-l10n-id="open_file">
               <span data-l10n-id="open_file_label">Open</span>
             </button>
 
@@ -122,7 +122,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
 
             <a href="#" id="secondaryViewBookmark" class="secondaryToolbarButton bookmark visibleSmallView" title="Current view (copy or open in new window)" data-l10n-id="bookmark">
               <span data-l10n-id="bookmark_label">Current View</span>
-          </a>
+          </a> -->
 
             <div class="horizontalToolbarSeparator visibleLargeView"></div>
 
@@ -185,7 +185,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
                   <span data-l10n-id="presentation_mode_label">Presentation Mode</span>
                 </button>
 
-                <button id="openFile" class="toolbarButton openFile hiddenLargeView" title="Open File" data-l10n-id="open_file">
+                <!-- <button id="openFile" class="toolbarButton openFile hiddenLargeView" title="Open File" data-l10n-id="open_file">
                   <span data-l10n-id="open_file_label">Open</span>
                 </button>
 
@@ -195,11 +195,11 @@ http://sourceforge.net/adobe/cmap/wiki/License/
 
                 <button id="download" class="toolbarButton download hiddenMediumView" title="Download" data-l10n-id="download">
                   <span data-l10n-id="download_label">Download</span>
-                </button>
+                </button> -->
                 <!-- <div class="toolbarButtonSpacer"></div> -->
-                <a href="#" id="viewBookmark" class="toolbarButton bookmark hiddenSmallView" title="Current view (copy or open in new window)" data-l10n-id="bookmark">
+                <!-- <a href="#" id="viewBookmark" class="toolbarButton bookmark hiddenSmallView" title="Current view (copy or open in new window)" data-l10n-id="bookmark">
                   <span data-l10n-id="bookmark_label">Current View</span>
-                </a>
+                </a> -->
 
                 <div class="verticalToolbarSeparator hiddenSmallView"></div>
                 
@@ -417,7 +417,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     </div>
   </div>
 </div>
-    <script type="text/javascript" src="${static.url('/static/js/vendor/pdfjs/viewer.js')}"></script>
-    <script type="text/javascript" src="${static.url('/static/js/pdf-analytics.js')}"></script>
+    <script type="text/javascript" src="${static.url('js/vendor/pdfjs/viewer.js')}"></script>
+    <script type="text/javascript" src="${static.url('js/pdf-analytics.js')}"></script>
   </body>
 </html>


### PR DESCRIPTION
Todo: We removed `/static/` prefix in the `pdf_viewer.html` file to get the PDF to render properly. Need to revisit why this was needed.