### PR TITLE
Update reset password email to include branding for subsites.

### DIFF
--- a/openedx/core/djangoapps/ace_common/template_context.py
+++ b/openedx/core/djangoapps/ace_common/template_context.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.urls import reverse
 
 from edxmako.shortcuts import marketing_link
+from branding import api as branding_api
 from openedx.core.djangoapps.theming.helpers import get_config_value_from_site_or_settings
 
 
@@ -16,6 +17,7 @@ def get_base_template_context(site):
         # Platform information
         'homepage_url': marketing_link('ROOT'),
         'dashboard_url': reverse('dashboard'),
+        'logo_image_url': branding_api.get_logo_url(),
         'template_revision': getattr(settings, 'EDX_PLATFORM_REVISION', None),
         'platform_name': get_config_value_from_site_or_settings(
             'PLATFORM_NAME',

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -61,7 +61,7 @@
                     <tr>
                         <td width="70">
                             <a href="{% with_link_tracking homepage_url %}"><img
-                                    src="https://media.sailthru.com/595/1k1/8/o/599f355101b3f.png" width="70"
+                                    src="{% with_link_tracking logo_image_url %}" width="70"
                                     height="30" alt="{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}"/></a>
                         </td>
                         <td align="right" style="text-align: {{ LANGUAGE_BIDI|yesno:"left,right" }};">
@@ -171,8 +171,10 @@
                         <td>
                             &copy; {% now "Y" %} {{ platform_name }}, {% trans "All rights reserved" %}.<br/>
                             <br/>
-                            {% trans "Our mailing address is" %}:<br/>
-                            {{ contact_mailing_address }}
+                            {% if contact_mailing_address %}
+                                {% trans "Our mailing address is" %}:<br/>
+                                {{ contact_mailing_address }}
+                            {% endif %}
                         </td>
                     </tr>
                 </table>


### PR DESCRIPTION
- The logo was always pulling from edX from `media.sailthru.com` and was not being updated through the site configuration `logo_image_url`.
- Hide `contact_mailing_address` if not defined in site configuration. This is because most subsites don't have mailing addresses.