### PR TITLE
Fixed issue with `CourseBadgesTab` is_enabled check. EW-525

### DIFF
--- a/openedx/features/course_badges/plugins.py
+++ b/openedx/features/course_badges/plugins.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.utils.translation import ugettext_noop
 
 from courseware.tabs import EnrolledTab
-
+from lms.djangoapps.courseware.courses import get_course_by_id
 
 class CourseBadgesTab(EnrolledTab):
     """
@@ -34,16 +34,22 @@ class CourseBadgesTab(EnrolledTab):
         if not super(CourseBadgesTab, cls).is_enabled(course, user=user):
             return False
 
-        if not is_feature_enabled(course):
+        if not is_feature_enabled():
             return False
 
         if user and not user.is_authenticated:
             return False
 
-        return course.issue_badges
+        # Retrieve the Advanced Settings Issue Open Badges (`issue_badges`) field from the CourseFields instance.
+        # CourseDescriptorWithMixins will be `course` instance when called from the `^/api/courseware/course/` url.
+        # CourseOverview will be `course` instance when called from the `^courses/{}/courseware` url.
+        if course.id:
+            course_fields = get_course_by_id(course.id)
+            return course_fields.issue_badges
 
+        return False
 
-def is_feature_enabled(course):
+def is_feature_enabled():
     """
     Returns True if the teams feature is enabled.
     """


### PR DESCRIPTION
When serializing the `tabs` for field for `lms.djangoapps.courseware.tabs.CourseInfoTab` there was an error retrieving the `issue_badges` property for the `course` instance for `CourseBadgesTab` since the instance was a `CourseOverview` class. That field is found from the `CourseDescriptorWithMixins` class only for that course advanced field setting. This commit fixes that issue.