### PR TITLE
Setup signal handler when user logs in to setup paid BigCommerce Products (e.g. LMS courses)

### DIFF
--- a/lms/djangoapps/bigcommerce_app/apps.py
+++ b/lms/djangoapps/bigcommerce_app/apps.py
@@ -1,0 +1,21 @@
+"""
+BigCommerce Application Configuration
+
+Signal handlers are connected here.
+"""
+
+
+from django.apps import AppConfig
+
+
+class BigCommerceAppConfig(AppConfig):
+    """
+    Application Configuration for BigCommerce.
+    """
+    name = u'bigcommerce_app'
+
+    def ready(self):
+        """
+        Connect signal handlers.
+        """
+        from . import handlers  # pylint: disable=unused-import

--- a/lms/djangoapps/bigcommerce_app/callbacks/urls.py
+++ b/lms/djangoapps/bigcommerce_app/callbacks/urls.py
@@ -6,8 +6,7 @@ from django.urls import re_path
 from django.conf import settings
 from django.conf.urls import include, url
 
-# from badges.apis.v1 import views
-from bigcommerce_app.callbacks import views
+from lms.djangoapps.bigcommerce_app.callbacks import views
 
 app_name = 'v1'
 urlpatterns = []

--- a/lms/djangoapps/bigcommerce_app/callbacks/views.py
+++ b/lms/djangoapps/bigcommerce_app/callbacks/views.py
@@ -1,5 +1,5 @@
 """
-API views for badges
+BigCommerce Single-Click app endpoints
 """
 
 import logging
@@ -9,8 +9,8 @@ from django.shortcuts import redirect, reverse
 # from django.urls import reverse
 
 from bigcommerce.api import BigcommerceApi
-from bigcommerce_app.utils import internal_server_error, client_id, client_secret, platform_lms_url
-from bigcommerce_app.models import Store, AdminUser, StoreAdminUser
+from lms.djangoapps.bigcommerce_app.utils import internal_server_error, client_id, client_secret, platform_lms_url
+from lms.djangoapps.bigcommerce_app.models import Store, AdminUser, StoreAdminUser
 
 LOGGER = logging.getLogger(__name__)
 
@@ -85,8 +85,6 @@ class BigCommerceAppCallbacks():
             store_admin_user.is_admin = True
         store_admin_user.save()
 
-        # response = redirect(platform_lms_url() + "/bigcommerce/single-click/index/")
-        # reverse("badges_api:v1:badges-user-assertions", kwargs={'username': request.user})
         response = redirect(reverse("bigcommerce_app_single_click:index") + '?bc_storeadminuserid={id}'.format(id=store_admin_user.bc_admin_user.bc_id))
         
         # Todo: This doesn't work at the moment.
@@ -143,8 +141,6 @@ class BigCommerceAppCallbacks():
         store_admin_user, __ = StoreAdminUser.objects.get_or_create(store_id=store.id, bc_admin_user_id=admin_user.id)
         store_admin_user.save()
 
-        # response = redirect(platform_lms_url() + "/bigcommerce/single-click/index/")
-        # reverse("badges_api:v1:badges-user-assertions", kwargs={'username': request.user})
         response = redirect(reverse("bigcommerce_app_single_click:index") + '?bc_storeadminuserid={id}'.format(id=store_admin_user.bc_admin_user.bc_id))
         
         # Todo: This doesn't work at the moment.

--- a/lms/djangoapps/bigcommerce_app/events/course_enrollment.py
+++ b/lms/djangoapps/bigcommerce_app/events/course_enrollment.py
@@ -1,0 +1,13 @@
+"""
+Events related to how BigCommerce Customers interface with the platform.
+"""
+
+from lms.djangoapps.bigcommerce_app import requires_bigcommerce_enabled
+
+
+@requires_bigcommerce_enabled
+def enroll_paid_bigcommerce_courses(user):
+    """
+    Enrolls BigCommerce Customers into platform courses based on products (e.g. BigCommerce Courses) paid for.
+    """
+    pass

--- a/lms/djangoapps/bigcommerce_app/handlers.py
+++ b/lms/djangoapps/bigcommerce_app/handlers.py
@@ -1,0 +1,18 @@
+"""
+BigCommerce related signal handlers.
+"""
+
+from django.contrib.auth.signals import user_logged_in
+from django.dispatch import receiver
+
+from lms.djangoapps.bigcommerce_app.events.course_enrollment import enroll_paid_bigcommerce_courses
+from lms.djangoapps.bigcommerce_app.utils import bigcommerce_enabled
+
+
+@receiver(user_logged_in)
+def enroll_courses_on_login(sender, event=None, user=None, **kwargs):  # pylint: disable=unused-argument
+    """
+    Registers platform users to paid BigCommerce products (e.g. Courses).
+    """
+    if bigcommerce_enabled:
+        enroll_paid_bigcommerce_courses(user)

--- a/lms/djangoapps/bigcommerce_app/models.py
+++ b/lms/djangoapps/bigcommerce_app/models.py
@@ -130,7 +130,8 @@ class StoreCustomerPlatformUser(models.Model):
 
         platform_user_store_customers = cls.objects.filter(platform_user=platform_user)
 
-        store_hash = configuration_helpers.get_value('BIGCOMMERCE_APP_STORE_HASH', settings.BIGCOMMERCE_APP_STORE_HASH)
+        store_hash = configuration_helpers.get_value_for_org('BIGCOMMERCE_APP_STORE_HASH', "SITE_NAME", settings.BIGCOMMERCE_APP_STORE_HASH)
+
         if store_hash:
             bc_site_store = Store.objects.get(store_hash=store_hash)
             

--- a/lms/djangoapps/bigcommerce_app/single_click/urls.py
+++ b/lms/djangoapps/bigcommerce_app/single_click/urls.py
@@ -6,7 +6,7 @@ from django.urls import re_path
 from django.conf import settings
 from django.conf.urls import include, url
 
-from bigcommerce_app.single_click import views
+from lms.djangoapps.bigcommerce_app.single_click import views
 
 app_name = 'v1'
 urlpatterns = []

--- a/lms/djangoapps/bigcommerce_app/single_click/views.py
+++ b/lms/djangoapps/bigcommerce_app/single_click/views.py
@@ -7,8 +7,8 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 from edxmako.shortcuts import render_to_response
 
 from bigcommerce.api import BigcommerceApi
-from bigcommerce_app.models import Store, AdminUser, StoreAdminUser
-from bigcommerce_app.utils import client_id
+from lms.djangoapps.bigcommerce_app.models import StoreAdminUser
+from lms.djangoapps.bigcommerce_app.utils import client_id
 
 LOGGER = logging.getLogger(__name__)
 _ = translation.ugettext

--- a/lms/djangoapps/bigcommerce_app/tests/factories.py
+++ b/lms/djangoapps/bigcommerce_app/tests/factories.py
@@ -6,7 +6,7 @@ import json
 import factory
 from factory import DjangoModelFactory
 
-from bigcommerce_app.models import (
+from lms.djangoapps.bigcommerce_app.models import (
     Store, 
     AdminUser, 
     StoreAdminUser, 

--- a/lms/djangoapps/bigcommerce_app/tests/test_models.py
+++ b/lms/djangoapps/bigcommerce_app/tests/test_models.py
@@ -4,7 +4,7 @@ from django.test.utils import override_settings
 
 from mock import Mock
 
-from bigcommerce_app.models import (
+from lms.djangoapps.bigcommerce_app.models import (
     Store, 
     AdminUser, 
     StoreAdminUser, 
@@ -13,7 +13,7 @@ from bigcommerce_app.models import (
     StoreCustomerPlatformUser
 )
 
-from bigcommerce_app.tests.factories import (
+from lms.djangoapps.bigcommerce_app.tests.factories import (
     StoreFactory,
     RandomStoreFactory,
     CustomerFactory,

--- a/lms/djangoapps/bigcommerce_app/utils.py
+++ b/lms/djangoapps/bigcommerce_app/utils.py
@@ -7,6 +7,26 @@ from django.http import HttpResponse
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
+def requires_bigcommerce_enabled(function):
+    """
+    Decorator that bails a function out early if bigcommerce isn't enabled.
+    """
+    def wrapped(*args, **kwargs):
+        """
+        Wrapped function which bails out early if bagdes aren't enabled.
+        """
+        if not bigcommerce_enabled():
+            return
+        return function(*args, **kwargs)
+    return wrapped
+
+
+def bigcommerce_enabled():
+    """
+    returns a boolean indicating whether or not BigCommerce app is enabled.
+    """
+    return configuration_helpers.get_value_for_org('ENABLE_BIGCOMMERCE', "SITE_NAME", settings.ENABLE_BIGCOMMERCE)
+
 #
 # Error handling and helpers
 #
@@ -28,12 +48,12 @@ def internal_server_error(e):
 
 
 def client_id():
-    return configuration_helpers.get_value('BIGCOMMERCE_APP_CLIENT_ID', settings.BIGCOMMERCE_APP_CLIENT_ID)
+    return configuration_helpers.get_value_for_org('BIGCOMMERCE_APP_CLIENT_ID', "SITE_NAME", settings.BIGCOMMERCE_APP_CLIENT_ID)
 
 
 def client_secret():
-    return configuration_helpers.get_value('BIGCOMMERCE_APP_CLIENT_SECRET', settings.BIGCOMMERCE_APP_CLIENT_SECRET)
+    return configuration_helpers.get_value_for_org('BIGCOMMERCE_APP_CLIENT_SECRET', "SITE_NAME", settings.BIGCOMMERCE_APP_CLIENT_SECRET)
 
 
 def platform_lms_url():
-    return configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL)
+    return configuration_helpers.get_value_for_org('LMS_ROOT_URL', "SITE_NAME", settings.LMS_ROOT_URL)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2590,6 +2590,9 @@ INSTALLED_APPS = [
     # Management of per-user schedules
     'openedx.core.djangoapps.schedules',
     'rest_framework_jwt',
+
+    # BigCommerce App
+    'lms.djangoapps.bigcommerce_app',
 ]
 
 ######################### CSRF #########################################
@@ -2906,7 +2909,6 @@ QUALTRICS_API_TOKEN = None
 
 #################### BigCommerce Settings #######################
 
-# BIGCOMMERCE_APP_ACCESS_TOKEN = None
 BIGCOMMERCE_APP_CLIENT_ID = None
 BIGCOMMERCE_APP_CLIENT_SECRET = None
 BIGCOMMERCE_APP_STORE_HASH = None

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -608,12 +608,9 @@ FEATURES.update({
 })
 
 if FEATURES.get('ENABLE_BIGCOMMERCE'):
-    # BIGCOMMERCE_APP_ACCESS_TOKEN="rg2zptq3s9x1nzh8sttgy8zcjgd9gyu"
     BIGCOMMERCE_APP_CLIENT_ID="6ms4rvrkhnv5m3h1o582mtqb7wzixyr"
     BIGCOMMERCE_APP_CLIENT_SECRET="385d434a82fe40cd838ad5891bdbc1548209547112f1e81c4b16bc2842d1a329"
     BIGCOMMERCE_APP_STORE_HASH="1nol3cto8"
     BIGCOMMERCE_APP_STORE_URL="https://educateworkforce-development.mybigcommerce.com"
 
     INSTALLED_APPS.append('bigcommerce')
-    INSTALLED_APPS.append('bigcommerce_app')
-

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -190,12 +190,12 @@ if settings.FEATURES.get('ENABLE_BIGCOMMERCE'):
     urlpatterns += [
         # Callback Endpoints
         url(r'^bigcommerce/callbacks/', 
-            include(('bigcommerce_app.callbacks.urls', 'bigcommerce_app'), namespace='bigcommerce_app_callbacks')),
+            include(('lms.djangoapps.bigcommerce_app.callbacks.urls', 'lms.djangoapps.bigcommerce_app'), namespace='bigcommerce_app_callbacks')),
     ]
     urlpatterns += [
         # Single-Click App Endpoints
         url(r'^bigcommerce/single-click/', 
-            include(('bigcommerce_app.single_click.urls', 'bigcommerce_app'), namespace='bigcommerce_app_single_click')),
+            include(('lms.djangoapps.bigcommerce_app.single_click.urls', 'lms.djangoapps.bigcommerce_app'), namespace='bigcommerce_app_single_click')),
     ]
 
 urlpatterns += [


### PR DESCRIPTION
- Restructured imports to include `lms.djangoapps.bigcommerce_app` paths.
- Setup signal to listen on `user_logged_in` event dispatch to enroll paid BigCommerce Products (e.g. LMS courses) for the user.