### PR TITLE
Fix session cookie domain for platform login cookies and handled attribute exception with customer orders for BigCommerce.

### DIFF
--- a/common/djangoapps/student/cookies.py
+++ b/common/djangoapps/student/cookies.py
@@ -14,6 +14,7 @@ from django.dispatch import Signal
 from django.utils.http import cookie_date
 
 from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from student.models import CourseEnrollment
 
 CREATE_LOGON_COOKIE = Signal(providing_args=['user', 'response'])
@@ -33,7 +34,7 @@ def standard_cookie_settings(request):
     cookie_settings = {
         'max_age': max_age,
         'expires': expires,
-        'domain': settings.SESSION_COOKIE_DOMAIN,
+        'domain': configuration_helpers.get_value('SESSION_COOKIE_DOMAIN', settings.SESSION_COOKIE_DOMAIN),
         'path': '/',
         'httponly': None,
     }

--- a/lms/djangoapps/bigcommerce_app/utils.py
+++ b/lms/djangoapps/bigcommerce_app/utils.py
@@ -300,24 +300,33 @@ class BigCommerceAPI():
         bcapi_client = cls().api_client
 
         if bcapi_client:
-            try:
-                orders = bcapi_client.Orders.all(customer_id=customer_id)
-            except:
-                return
-
             courses = []
 
-            for order in orders:
-                products = bcapi_client.OrderProducts.all(order.id)
+            try:
+                orders = bcapi_client.Orders.all(customer_id=customer_id)
+            except Exception as e:
+                LOGGER.error(
+                    u"Could not find BigCommerce Orders for {customer_id}".format(customer_id=customer_id)
+                )
+                return courses
 
-                for product in products:
-                    product_details = bcapi_client.Products.get(product.product_id)
-                    custom_fields = product_details.custom_fields()
+            try:
+                for order in orders:
+                    products = bcapi_client.OrderProducts.all(order.id)
 
-                    if custom_fields:
-                        for field in custom_fields:
-                            if isinstance(field, ProductCustomFields) and field.name == 'Course ID':
-                                courses.append(field.text)
+                    for product in products:
+                        product_details = bcapi_client.Products.get(product.product_id)
+                        custom_fields = product_details.custom_fields()
+
+                        if custom_fields:
+                            for field in custom_fields:
+                                if isinstance(field, ProductCustomFields) and field.name == 'Course ID':
+                                    courses.append(field.text)
+            except AttributeError as e:
+                LOGGER.error(
+                    u"Could not find BigCommerce orders for the customer."
+                )
+                return courses
 
             return courses
 


### PR DESCRIPTION
- Resolve AttributeError with Bigcommerce Orders when the Customer has not place any orders. I couldn't figure out how to check the Orders count so unfortunately we exit this function whenever the `order.id` attribute fails.
- Finalized the `social_core` pipeline for `third_party_auth.pipeline.set_logged_in_cookies` by setting the `SESSION_COOKIE_DOMAIN` to the one defined in Site Configuration. If we didn't do this then there would be a lot of failed redirects because the cookie domain was wrong for the site.