### PR TITLE
Make Account Settings `Linked Accounts` and `Order History` show per SiteConfiguration.

### DIFF
--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -570,6 +570,12 @@ def account_settings_context(request):
         'enable_account_deletion': configuration_helpers.get_value(
             'ENABLE_ACCOUNT_DELETION', settings.FEATURES.get('ENABLE_ACCOUNT_DELETION', False)
         ),
+        'enable_account_linked_accounts': configuration_helpers.get_value(
+            'ENABLE_ACCOUNT_LINKED_ACCOUNTS', settings.FEATURES.get('ENABLE_ACCOUNT_LINKED_ACCOUNTS', False)
+        ),
+        'enable_account_order_history': configuration_helpers.get_value(
+            'ENABLE_ACCOUNT_ORDER_HISTORY', settings.FEATURES.get('ENABLE_ACCOUNT_ORDER_HISTORY', False)
+        ),
         'extended_profile_fields': _get_extended_profile_fields(),
     }
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -406,6 +406,12 @@ FEATURES = {
 
     # Whether to display the account deletion section the account settings page
     'ENABLE_ACCOUNT_DELETION': True,
+
+    # Whether to display the account linked accounts view.
+    'ENABLE_ACCOUNT_LINKED_ACCOUNTS': True,
+
+    # Whether to display the account order history view.
+    'ENABLE_ACCOUNT_ORDER_HISTORY': True,
 }
 
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -27,7 +27,9 @@
             enterpriseReadonlyAccountFields,
             edxSupportUrl,
             extendedProfileFields,
-            displayAccountDeletion
+            displayAccountDeletion,
+            displayAccountLinkedAccounts,
+            displayAccountOrderHistory
         ) {
             var $accountSettingsElement, userAccountModel, userPreferencesModel, aboutSectionsData,
                 accountsSectionData, ordersSectionData, accountSettingsView, showAccountSettingsPage,
@@ -316,29 +318,32 @@
             countryDropdownField = getUserField(userFields, 'country');
             timeZoneDropdownField.listenToCountryView(countryDropdownField);
 
-            accountsSectionData = [
-                {
-                    title: gettext('Linked Accounts'),
-                    subtitle: StringUtils.interpolate(
-                        gettext('You can link your social media accounts to simplify signing in to {platform_name}.'),
-                        {platform_name: platformName}
-                    ),
-                    fields: _.map(authData.providers, function(provider) {
-                        return {
-                            view: new AccountSettingsFieldViews.AuthFieldView({
-                                title: provider.name,
-                                valueAttribute: 'auth-' + provider.id,
-                                helpMessage: '',
-                                connected: provider.connected,
-                                connectUrl: provider.connect_url,
-                                acceptsLogins: provider.accepts_logins,
-                                disconnectUrl: provider.disconnect_url,
-                                platformName: platformName
-                            })
-                        };
-                    })
-                }
-            ];
+            accountsSectionData = []
+            if ( displayAccountLinkedAccounts ) {
+                accountsSectionData = [
+                    {
+                        title: gettext('Linked Accounts'),
+                        subtitle: StringUtils.interpolate(
+                            gettext('You can link your social media accounts to simplify signing in to {platform_name}.'),
+                            {platform_name: platformName}
+                        ),
+                        fields: _.map(authData.providers, function(provider) {
+                            return {
+                                view: new AccountSettingsFieldViews.AuthFieldView({
+                                    title: provider.name,
+                                    valueAttribute: 'auth-' + provider.id,
+                                    helpMessage: '',
+                                    connected: provider.connected,
+                                    connectUrl: provider.connect_url,
+                                    acceptsLogins: provider.accepts_logins,
+                                    disconnectUrl: provider.disconnect_url,
+                                    platformName: platformName
+                                })
+                            };
+                        })
+                    }
+                ];
+            }
 
             ordersHistoryData.unshift(
                 {
@@ -349,31 +354,34 @@
                 }
             );
 
-            ordersSectionData = [
-                {
-                    title: gettext('My Orders'),
-                    subtitle: StringUtils.interpolate(
-                        gettext('This page contains information about orders that you have placed with {platform_name}.'),  // eslint-disable-line max-len
-                        {platform_name: platformName}
-                    ),
-                    fields: _.map(ordersHistoryData, function(order) {
-                        orderNumber = order.number;
-                        if (orderNumber === 'ORDER NUMBER') {
-                            orderNumber = 'orderId';
-                        }
-                        return {
-                            view: new AccountSettingsFieldViews.OrderHistoryFieldView({
-                                totalPrice: order.price,
-                                orderId: order.number,
-                                orderDate: order.order_date,
-                                receiptUrl: order.receipt_url,
-                                valueAttribute: 'order-' + orderNumber,
-                                lines: order.lines
-                            })
-                        };
-                    })
-                }
-            ];
+            ordersSectionData = []
+            if ( displayAccountOrderHistory ) {
+                ordersSectionData = [
+                    {
+                        title: gettext('My Orders'),
+                        subtitle: StringUtils.interpolate(
+                            gettext('This page contains information about orders that you have placed with {platform_name}.'),  // eslint-disable-line max-len
+                            {platform_name: platformName}
+                        ),
+                        fields: _.map(ordersHistoryData, function(order) {
+                            orderNumber = order.number;
+                            if (orderNumber === 'ORDER NUMBER') {
+                                orderNumber = 'orderId';
+                            }
+                            return {
+                                view: new AccountSettingsFieldViews.OrderHistoryFieldView({
+                                    totalPrice: order.price,
+                                    orderId: order.number,
+                                    orderDate: order.order_date,
+                                    receiptUrl: order.receipt_url,
+                                    valueAttribute: 'order-' + orderNumber,
+                                    lines: order.lines
+                                })
+                            };
+                        })
+                    }
+                ];
+            }
 
             accountSettingsView = new AccountSettingsView({
                 model: userAccountModel,

--- a/lms/static/js/student_account/views/account_settings_view.js
+++ b/lms/static/js/student_account/views/account_settings_view.js
@@ -9,37 +9,40 @@
         'js/student_account/views/account_section_view',
         'text!templates/student_account/account_settings.underscore'
     ], function(gettext, $, _, TabbedView, HtmlUtils, AccountSectionView, accountSettingsTemplate) {
+
+        var accountSettingsTabsConfig = [
+            {
+                name: 'aboutTabSections',
+                id: 'about-tab',
+                label: gettext('Account Information'),
+                class: 'active',
+                tabindex: 0,
+                selected: true,
+                expanded: true
+            }
+        ];
+        var accountLinkedAccounts = {
+                name: 'accountsTabSections',
+                id: 'accounts-tab',
+                label: gettext('Linked Accounts'),
+                tabindex: -1,
+                selected: false,
+                expanded: false
+            };
+        var accountOrdersTabSections = {
+            name: 'ordersTabSections',
+            id: 'orders-tab',
+            label: gettext('Order History'),
+            tabindex: -1,
+            selected: false,
+            expanded: false
+        };
+
         var AccountSettingsView = TabbedView.extend({
 
             navLink: '.account-nav-link',
             activeTab: 'aboutTabSections',
-            accountSettingsTabs: [
-                {
-                    name: 'aboutTabSections',
-                    id: 'about-tab',
-                    label: gettext('Account Information'),
-                    class: 'active',
-                    tabindex: 0,
-                    selected: true,
-                    expanded: true
-                },
-                {
-                    name: 'accountsTabSections',
-                    id: 'accounts-tab',
-                    label: gettext('Linked Accounts'),
-                    tabindex: -1,
-                    selected: false,
-                    expanded: false
-                },
-                {
-                    name: 'ordersTabSections',
-                    id: 'orders-tab',
-                    label: gettext('Order History'),
-                    tabindex: -1,
-                    selected: false,
-                    expanded: false
-                }
-            ],
+            accountSettingsTabs: accountSettingsTabsConfig,
             events: {
                 'click .account-nav-link': 'switchTab',
                 'keydown .account-nav-link': 'keydownHandler'
@@ -52,7 +55,20 @@
 
             render: function() {
                 var tabName,
-                    view = this;
+                    view = this;   
+
+                // Add in the `Linked Accounts` tab if enabled in Site Configuration
+                if (view.options.tabSections['accountsTabSections'].length > 0 ) {
+                    accountSettingsTabsConfig.push(accountLinkedAccounts);
+                    this.accountSettingsTabs = accountSettingsTabsConfig;
+                }
+
+                // Add in the `Order History` tab if enabled in Site Configuration
+                if (view.options.tabSections['ordersTabSections'].length > 0 ) {
+                    accountSettingsTabsConfig.push(accountOrdersTabSections);
+                    this.accountSettingsTabs = accountSettingsTabsConfig;
+                }
+
                 HtmlUtils.setHtml(this.$el, HtmlUtils.template(accountSettingsTemplate)({
                     accountSettingsTabs: this.accountSettingsTabs
                 }));

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -45,7 +45,9 @@ from webpack_loader.templatetags.webpack_loader import render_bundle
         enterpriseReadonlyAccountFields = ${ enterprise_readonly_account_fields | n, dump_js_escaped_json },
         edxSupportUrl = '${ edx_support_url | n, js_escaped_string }',
         extendedProfileFields = ${ extended_profile_fields | n, dump_js_escaped_json },
-        displayAccountDeletion = ${ enable_account_deletion | n, dump_js_escaped_json};
+        displayAccountDeletion = ${ enable_account_deletion | n, dump_js_escaped_json},
+        displayAccountLinkedAccounts = ${ enable_account_linked_accounts | n, dump_js_escaped_json},
+        displayAccountOrderHistory = ${ enable_account_order_history | n, dump_js_escaped_json};
 
     AccountSettingsFactory(
         fieldsData,
@@ -65,7 +67,9 @@ from webpack_loader.templatetags.webpack_loader import render_bundle
         enterpriseReadonlyAccountFields,
         edxSupportUrl,
         extendedProfileFields,
-        displayAccountDeletion
+        displayAccountDeletion,
+        displayAccountLinkedAccounts,
+        displayAccountOrderHistory
     );
 </%static:require_module>
 


### PR DESCRIPTION
Restricting access to these tabbed Account Settings pages per subsite. If a subsite doesn't define an override then the tabs will display by default.