### PR TITLE
Make Account Settings `Linked Accounts` and `Order History` show per SiteConfiguration.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -486,6 +486,12 @@ FEATURES = {
     # .. toggle_status: supported
     # .. toggle_warnings: None
     'ENABLE_ORA_USER_STATE_UPLOAD_DATA': False,
+
+    # Whether to display the account linked accounts view.
+    'ENABLE_ACCOUNT_LINKED_ACCOUNTS': True,
+
+    # Whether to display the account order history view.
+    'ENABLE_ACCOUNT_ORDER_HISTORY': True,
 }
 
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -12,6 +12,7 @@
                  AccountSettingsFieldViews, AccountSettingsView, StringUtils, HtmlUtils) {
         return function(
             fieldsData,
+            disableLinkedAccountsTab,
             disableOrderHistoryTab,
             ordersHistoryData,
             authData,
@@ -353,29 +354,32 @@
             countryDropdownField = getUserField(userFields, 'country');
             timeZoneDropdownField.listenToCountryView(countryDropdownField);
 
-            accountsSectionData = [
-                {
-                    title: gettext('Linked Accounts'),
-                    subtitle: StringUtils.interpolate(
-                        gettext('You can link your social media accounts to simplify signing in to {platform_name}.'),
-                        {platform_name: platformName}
-                    ),
-                    fields: _.map(authData.providers, function(provider) {
-                        return {
-                            view: new AccountSettingsFieldViews.AuthFieldView({
-                                title: provider.name,
-                                valueAttribute: 'auth-' + provider.id,
-                                helpMessage: '',
-                                connected: provider.connected,
-                                connectUrl: provider.connect_url,
-                                acceptsLogins: provider.accepts_logins,
-                                disconnectUrl: provider.disconnect_url,
-                                platformName: platformName
-                            })
-                        };
-                    })
-                }
-            ];
+            accountsSectionData = []
+            if ( !disableLinkedAccountsTab ) {
+                accountsSectionData = [
+                    {
+                        title: gettext('Linked Accounts'),
+                        subtitle: StringUtils.interpolate(
+                            gettext('You can link your social media accounts to simplify signing in to {platform_name}.'),
+                            {platform_name: platformName}
+                        ),
+                        fields: _.map(authData.providers, function(provider) {
+                            return {
+                                view: new AccountSettingsFieldViews.AuthFieldView({
+                                    title: provider.name,
+                                    valueAttribute: 'auth-' + provider.id,
+                                    helpMessage: '',
+                                    connected: provider.connected,
+                                    connectUrl: provider.connect_url,
+                                    acceptsLogins: provider.accepts_logins,
+                                    disconnectUrl: provider.disconnect_url,
+                                    platformName: platformName
+                                })
+                            };
+                        })
+                    }
+                ];
+            }
 
             ordersHistoryData.unshift(
                 {
@@ -386,31 +390,34 @@
                 }
             );
 
-            ordersSectionData = [
-                {
-                    title: gettext('My Orders'),
-                    subtitle: StringUtils.interpolate(
-                        gettext('This page contains information about orders that you have placed with {platform_name}.'),  // eslint-disable-line max-len
-                        {platform_name: platformName}
-                    ),
-                    fields: _.map(ordersHistoryData, function(order) {
-                        orderNumber = order.number;
-                        if (orderNumber === 'ORDER NUMBER') {
-                            orderNumber = 'orderId';
-                        }
-                        return {
-                            view: new AccountSettingsFieldViews.OrderHistoryFieldView({
-                                totalPrice: order.price,
-                                orderId: order.number,
-                                orderDate: order.order_date,
-                                receiptUrl: order.receipt_url,
-                                valueAttribute: 'order-' + orderNumber,
-                                lines: order.lines
-                            })
-                        };
-                    })
-                }
-            ];
+            ordersSectionData = []
+            if ( !disableOrderHistoryTab ) {
+                ordersSectionData = [
+                    {
+                        title: gettext('My Orders'),
+                        subtitle: StringUtils.interpolate(
+                            gettext('This page contains information about orders that you have placed with {platform_name}.'),  // eslint-disable-line max-len
+                            {platform_name: platformName}
+                        ),
+                        fields: _.map(ordersHistoryData, function(order) {
+                            orderNumber = order.number;
+                            if (orderNumber === 'ORDER NUMBER') {
+                                orderNumber = 'orderId';
+                            }
+                            return {
+                                view: new AccountSettingsFieldViews.OrderHistoryFieldView({
+                                    totalPrice: order.price,
+                                    orderId: order.number,
+                                    orderDate: order.order_date,
+                                    receiptUrl: order.receipt_url,
+                                    valueAttribute: 'order-' + orderNumber,
+                                    lines: order.lines
+                                })
+                            };
+                        })
+                    }
+                ];
+            }
 
             accountSettingsView = new AccountSettingsView({
                 model: userAccountModel,
@@ -422,6 +429,7 @@
                     ordersTabSections: ordersSectionData
                 },
                 userPreferencesModel: userPreferencesModel,
+                disableLinkedAccountsTab: disableLinkedAccountsTab,
                 disableOrderHistoryTab: disableOrderHistoryTab,
                 betaLanguage: betaLanguage
             });

--- a/lms/static/js/student_account/views/account_settings_view.js
+++ b/lms/static/js/student_account/views/account_settings_view.js
@@ -36,16 +36,18 @@
                         tabindex: 0,
                         selected: true,
                         expanded: true
-                    },
-                    {
+                    }
+                ];
+                if (!view.options.disableLinkedAccountsTab) {
+                    accountSettingsTabs.push({
                         name: 'accountsTabSections',
                         id: 'accounts-tab',
                         label: gettext('Linked Accounts'),
                         tabindex: -1,
                         selected: false,
                         expanded: false
-                    }
-                ];
+                    });
+                }
                 if (!view.options.disableOrderHistoryTab) {
                     accountSettingsTabs.push({
                         name: 'ordersTabSections',

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -51,6 +51,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
 
     AccountSettingsFactory(
         fieldsData,
+        ${ disable_linked_accounts_tab | n, dump_js_escaped_json},
         ${ disable_order_history_tab | n, dump_js_escaped_json },
         ordersHistoryData,
         authData,

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -138,7 +138,12 @@ def account_settings_context(request):
         'show_program_listing': ProgramsApiConfig.is_enabled(),
         'show_dashboard_tabs': True,
         'order_history': user_orders,
-        'disable_order_history_tab': should_redirect_to_order_history_microfrontend(),
+        'disable_linked_accounts_tab': not configuration_helpers.get_value(
+            'ENABLE_ACCOUNT_LINKED_ACCOUNTS', settings.FEATURES.get('ENABLE_ACCOUNT_LINKED_ACCOUNTS', False)
+        ),
+        'disable_order_history_tab': should_redirect_to_order_history_microfrontend() or not configuration_helpers.get_value(
+            'ENABLE_ACCOUNT_ORDER_HISTORY', settings.FEATURES.get('ENABLE_ACCOUNT_ORDER_HISTORY', False)
+        ),
         'enable_account_deletion': configuration_helpers.get_value(
             'ENABLE_ACCOUNT_DELETION', settings.FEATURES.get('ENABLE_ACCOUNT_DELETION', False)
         ),


### PR DESCRIPTION
Restricting access to these tabbed Account Settings pages per subsite. If a subsite doesn't define an override then the tabs will display by default.