### PR TITLE
chore: Update Probot Github app to auto-assign reviewers to PR

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,17 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: true
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers: 
+  - @CUCWD/educateworkforce-platform-review
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it 
+skipKeywords:
+  - wip
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0


### PR DESCRIPTION
Auto assigning the https://github.com/orgs/CUCWD/teams/educateworkforce-platform-review team when PR is opened for the platform codebase.