### PR TITLE
feat(badging): Handling cases when Badge tab is disabled.

### DIFF
--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -330,9 +330,9 @@ class BadgesTab(EnrolledTab):
     type = "badges_progress"
     title = gettext_noop(
         "Badges")  # We don't have the user in this context, so we don't want to translate it at this level.
-    priority = 50
+    priority = None
     view_name = "badges_progress"
-    is_dynamic = True
+    is_default = True
     is_movable = True
     is_hideable = True
 

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -205,7 +205,7 @@ class TestCourseHomePage(CourseHomePageTestCase):  # lint-amnesty, pylint: disab
 
         # Fetch the view and verify the query counts
         # TODO: decrease query count as part of REVO-28
-        with self.assertNumQueries(73, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
+        with self.assertNumQueries(77, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
             with check_mongo_calls(4):
                 url = course_home_url(self.course)
                 self.client.get(url)


### PR DESCRIPTION
- Provided a way for the CMS to disable the `Badge` tab on the `Content > Pages` page even when `Advanced Settings > Issue Open Badges == true`.
- Return `block['badge_progress'] = False` whenever the `Badge` tab is disabled for the course. This prevents the Course Outline page from rendering `Badge Progress` for completed chapter content.