### PR TITLE
bug(registration): Missing required field `ethnicity` field length.

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -260,7 +260,7 @@ class AccountCreationForm(forms.Form):
                         )
                 else:
                     required = field_value == "required"
-                    min_length = 1 if field_name in ("gender", "level_of_education") else 2
+                    min_length = 1 if field_name in ("ethnicity", "gender", "level_of_education") else 2
                     error_message = error_message_dict.get(
                         field_name,
                         _("You are missing one or more required fields")

--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -167,7 +167,7 @@ class TestCreateAccount(SiteMixin, TestCase):
         year_of_birth = year - 14
         self.params.update({
             "level_of_education": "a",
-            "gender": "o",
+            "gender": "prefer-not-to-say",
             "mailing_address": "123 Example Rd",
             "city": "Exampleton",
             "country": "US",
@@ -183,9 +183,9 @@ class TestCreateAccount(SiteMixin, TestCase):
             'name': self.params['name'],
             'age': 13,
             'yearOfBirth': year_of_birth,
-            'education': 'Associate degree',
+            'education': '2-year degree',
             'address': self.params['mailing_address'],
-            'gender': 'Other/Prefer Not to Say',
+            'gender': 'Prefer not to say',
             'country': self.params['country'],
         }
 
@@ -200,7 +200,7 @@ class TestCreateAccount(SiteMixin, TestCase):
     def test_profile_saved_all_optional_fields(self):
         self.params.update({
             "level_of_education": "a",
-            "gender": "o",
+            "gender": "f",
             "mailing_address": "123 Example Rd",
             "city": "Exampleton",
             "country": "US",
@@ -211,7 +211,7 @@ class TestCreateAccount(SiteMixin, TestCase):
         })
         profile = self.create_account_and_fetch_profile()
         self.assertEqual(profile.level_of_education, "a")
-        self.assertEqual(profile.gender, "o")
+        self.assertEqual(profile.gender, "f")
         self.assertEqual(profile.mailing_address, "123 Example Rd")
         self.assertEqual(profile.city, "Exampleton")
         self.assertEqual(profile.country, "US")


### PR DESCRIPTION
Error during creation of new account. We received the following error even though we setup the `/edx/app/edxapp/lms.env.json` `REGISTRATION_EXTRA_FIELDS` to have all `required` field values with an actual value selected on the `/register` page.

![image](https://user-images.githubusercontent.com/5641338/185435102-9b8c54ef-e798-42eb-bc26-6db7cff00347.png)

**`/edx/app/edxapp/lms.env.json`**

![image](https://user-images.githubusercontent.com/5641338/185435537-fbb599ed-40d1-4608-8a6f-f03b98c02c5b.png)


It appeared that all required fields were defined in `REGISTRATION_EXTRA_FIELDS` correctly. 

After debugging the code it appeared that the `ethnicity` field had one field value of length set at 1 while other fields were set at > 1 in length. 

The call to verify registration fields at endpoint `v1/account/registration/` was failing due to a check on the `White` field with value `w` had minimum length set to 1.

We need to make sure that any fields that have this minimal character limit of 1 get added to this field check. For example some fields contain a `o` value for `Other`. We could either make sure that the field values say `other` or add then field name into this tuple for `min_length` check.

Resolve unit test failues for `edx-platform/common/djangoapps/student/tests`.
-  `gender` field `o` option going to `prefer-not-to-say`.
- `education` field going to `2-year degree`.

This appears to only be a bugfix for `hawthorn` seeing that `maple.3` sets `min_length = 1`.
https://github.com/openedx/edx-platform/blob/open-release/maple.3/openedx/core/djangoapps/user_authn/views/registration_form.py#L212-L225