### PR TITLE
Need to make sure the javascript libraries for old glossary are included.

### DIFF
--- a/common/static/js/vendor/jquery.easytabs.js
+++ b/common/static/js/vendor/jquery.easytabs.js
@@ -1,0 +1,704 @@
+/*
+ * jQuery EasyTabs plugin 3.2.0
+ *
+ * Copyright (c) 2010-2011 Steve Schwartz (JangoSteve)
+ *
+ * Dual licensed under the MIT and GPL licenses:
+ *   http://www.opensource.org/licenses/mit-license.php
+ *   http://www.gnu.org/licenses/gpl.html
+ *
+ * Date: Thu May 09 17:30:00 2013 -0500
+ */
+( function($) {
+
+  $.easytabs = function(container, options) {
+
+        // Attach to plugin anything that should be available via
+        // the $container.data('easytabs') object
+    var plugin = this,
+        $container = $(container),
+
+        defaults = {
+          animate: true,
+          panelActiveClass: "active",
+          tabActiveClass: "active",
+          defaultTab: "li:first-child",
+          animationSpeed: "normal",
+          tabs: "> ol > li",
+          updateHash: true,
+          cycle: false,
+          collapsible: false,
+          collapsedClass: "collapsed",
+          collapsedByDefault: true,
+          uiTabs: false,
+          transitionIn: 'fadeIn',
+          transitionOut: 'fadeOut',
+          transitionInEasing: 'swing',
+          transitionOutEasing: 'swing',
+          transitionCollapse: 'slideUp',
+          transitionUncollapse: 'slideDown',
+          transitionCollapseEasing: 'swing',
+          transitionUncollapseEasing: 'swing',
+          containerClass: "",
+          tabsClass: "",
+          tabClass: "",
+          panelClass: "",
+          cache: true,
+          event: 'click',
+          panelContext: $container
+        },
+
+        // Internal instance variables
+        // (not available via easytabs object)
+        $defaultTab,
+        $defaultTabLink,
+        transitions,
+        lastHash,
+        skipUpdateToHash,
+        animationSpeeds = {
+          fast: 200,
+          normal: 400,
+          slow: 600
+        },
+
+        // Shorthand variable so that we don't need to call
+        // plugin.settings throughout the plugin code
+        settings;
+
+    // =============================================================
+    // Functions available via easytabs object
+    // =============================================================
+
+    plugin.init = function() {
+
+      plugin.settings = settings = $.extend({}, defaults, options);
+      settings.bind_str = settings.event+".easytabs";
+
+      // Add jQuery UI's crazy class names to markup,
+      // so that markup will match theme CSS
+      if ( settings.uiTabs ) {
+        settings.tabActiveClass = 'ui-tabs-selected';
+        settings.containerClass = 'ui-tabs ui-widget ui-widget-content ui-corner-all';
+        settings.tabsClass = 'ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all';
+        settings.tabClass = 'ui-state-default ui-corner-top';
+        settings.panelClass = 'ui-tabs-panel ui-widget-content ui-corner-bottom';
+      }
+
+      // If collapsible is true and defaultTab specified, assume user wants defaultTab showing (not collapsed)
+      if ( settings.collapsible && options.defaultTab !== undefined && options.collpasedByDefault === undefined ) {
+        settings.collapsedByDefault = false;
+      }
+
+      // Convert 'normal', 'fast', and 'slow' animation speed settings to their respective speed in milliseconds
+      if ( typeof(settings.animationSpeed) === 'string' ) {
+        settings.animationSpeed = animationSpeeds[settings.animationSpeed];
+      }
+
+      $('a.anchor').remove().prependTo('body');
+
+      // Store easytabs object on container so we can easily set
+      // properties throughout
+      $container.data('easytabs', {});
+
+      plugin.setTransitions();
+
+      plugin.getTabs();
+
+      addClasses();
+
+      setDefaultTab();
+
+      bindToTabClicks();
+
+      initHashChange();
+
+      initCycle();
+
+      // Append data-easytabs HTML attribute to make easy to query for
+      // easytabs instances via CSS pseudo-selector
+      $container.attr('data-easytabs', true);
+    };
+
+    // Set transitions for switching between tabs based on options.
+    // Could be used to update transitions if settings are changes.
+    plugin.setTransitions = function() {
+      transitions = ( settings.animate ) ? {
+          show: settings.transitionIn,
+          hide: settings.transitionOut,
+          speed: settings.animationSpeed,
+          collapse: settings.transitionCollapse,
+          uncollapse: settings.transitionUncollapse,
+          halfSpeed: settings.animationSpeed / 2
+        } :
+        {
+          show: "show",
+          hide: "hide",
+          speed: 0,
+          collapse: "hide",
+          uncollapse: "show",
+          halfSpeed: 0
+        };
+    };
+
+    // Find and instantiate tabs and panels.
+    // Could be used to reset tab and panel collection if markup is
+    // modified.
+    plugin.getTabs = function() {
+      var $matchingPanel;
+
+      // Find the initial set of elements matching the setting.tabs
+      // CSS selector within the container
+      plugin.tabs = $container.find(settings.tabs),
+
+      // Instantiate panels as empty jquery object
+      plugin.panels = $(),
+
+      plugin.tabs.each(function(){
+        var $tab = $(this),
+            $a = $tab.children('a'),
+
+            // targetId is the ID of the panel, which is either the
+            // `href` attribute for non-ajax tabs, or in the
+            // `data-target` attribute for ajax tabs since the `href` is
+            // the ajax URL
+            targetId = $tab.children('a').data('target');
+
+        $tab.data('easytabs', {});
+
+        // If the tab has a `data-target` attribute, and is thus an ajax tab
+        if ( targetId !== undefined && targetId !== null ) {
+          $tab.data('easytabs').ajax = $a.attr('href');
+        } else {
+          targetId = $a.attr('href');
+        }
+        targetId = targetId.match(/#([^\?]+)/)[1];
+
+        $matchingPanel = settings.panelContext.find("#" + targetId);
+
+        // If tab has a matching panel, add it to panels
+        if ( $matchingPanel.length ) {
+
+          // Store panel height before hiding
+          $matchingPanel.data('easytabs', {
+            position: $matchingPanel.css('position'),
+            visibility: $matchingPanel.css('visibility')
+          });
+
+          // Don't hide panel if it's active (allows `getTabs` to be called manually to re-instantiate tab collection)
+          $matchingPanel.not(settings.panelActiveClass).hide();
+
+          plugin.panels = plugin.panels.add($matchingPanel);
+
+          $tab.data('easytabs').panel = $matchingPanel;
+
+        // Otherwise, remove tab from tabs collection
+        } else {
+          plugin.tabs = plugin.tabs.not($tab);
+          if ('console' in window) {
+            console.warn('Warning: tab without matching panel for selector \'#' + targetId +'\' removed from set');
+          }
+        }
+      });
+    };
+
+    // Select tab and fire callback
+    plugin.selectTab = function($clicked, callback) {
+      var url = window.location,
+          hash = url.hash.match(/^[^\?]*/)[0],
+          $targetPanel = $clicked.parent().data('easytabs').panel,
+          ajaxUrl = $clicked.parent().data('easytabs').ajax;
+
+      // Tab is collapsible and active => toggle collapsed state
+      if( settings.collapsible && ! skipUpdateToHash && ($clicked.hasClass(settings.tabActiveClass) || $clicked.hasClass(settings.collapsedClass)) ) {
+        plugin.toggleTabCollapse($clicked, $targetPanel, ajaxUrl, callback);
+
+      // Tab is not active and panel is not active => select tab
+      } else if( ! $clicked.hasClass(settings.tabActiveClass) || ! $targetPanel.hasClass(settings.panelActiveClass) ){
+        activateTab($clicked, $targetPanel, ajaxUrl, callback);
+
+      // Cache is disabled => reload (e.g reload an ajax tab).
+      } else if ( ! settings.cache ){
+        activateTab($clicked, $targetPanel, ajaxUrl, callback);
+      }
+
+    };
+
+    // Toggle tab collapsed state and fire callback
+    plugin.toggleTabCollapse = function($clicked, $targetPanel, ajaxUrl, callback) {
+      plugin.panels.stop(true,true);
+
+      if( fire($container,"easytabs:before", [$clicked, $targetPanel, settings]) ){
+        plugin.tabs.filter("." + settings.tabActiveClass).removeClass(settings.tabActiveClass).children().removeClass(settings.tabActiveClass);
+
+        // If panel is collapsed, uncollapse it
+        if( $clicked.hasClass(settings.collapsedClass) ){
+
+          // If ajax panel and not already cached
+          if( ajaxUrl && (!settings.cache || !$clicked.parent().data('easytabs').cached) ) {
+            $container.trigger('easytabs:ajax:beforeSend', [$clicked, $targetPanel]);
+
+            $targetPanel.load(ajaxUrl, function(response, status, xhr){
+              $clicked.parent().data('easytabs').cached = true;
+              $container.trigger('easytabs:ajax:complete', [$clicked, $targetPanel, response, status, xhr]);
+            });
+          }
+
+          // Update CSS classes of tab and panel
+          $clicked.parent()
+            .removeClass(settings.collapsedClass)
+            .addClass(settings.tabActiveClass)
+            .children()
+              .removeClass(settings.collapsedClass)
+              .addClass(settings.tabActiveClass);
+
+          $targetPanel
+            .addClass(settings.panelActiveClass)
+            [transitions.uncollapse](transitions.speed, settings.transitionUncollapseEasing, function(){
+              $container.trigger('easytabs:midTransition', [$clicked, $targetPanel, settings]);
+              if(typeof callback == 'function') callback();
+            });
+
+        // Otherwise, collapse it
+        } else {
+
+          // Update CSS classes of tab and panel
+          $clicked.addClass(settings.collapsedClass)
+            .parent()
+              .addClass(settings.collapsedClass);
+
+          $targetPanel
+            .removeClass(settings.panelActiveClass)
+            [transitions.collapse](transitions.speed, settings.transitionCollapseEasing, function(){
+              $container.trigger("easytabs:midTransition", [$clicked, $targetPanel, settings]);
+              if(typeof callback == 'function') callback();
+            });
+        }
+      }
+    };
+
+
+    // Find tab with target panel matching value
+    plugin.matchTab = function(hash) {
+      return plugin.tabs.find("[href='" + hash + "'],[data-target='" + hash + "']").first();
+    };
+
+    // Find panel with `id` matching value
+    plugin.matchInPanel = function(hash) {
+      return ( hash && plugin.validId(hash) ? plugin.panels.filter(':has(' + hash + ')').first() : [] );
+    };
+
+    // Make sure hash is a valid id value (admittedly strict in that HTML5 allows almost anything without a space)
+    // but jQuery has issues with such id values anyway, so we can afford to be strict here.
+    plugin.validId = function(id) {
+      return id.substr(1).match(/^[A-Za-z]+[A-Za-z0-9\-_:\.].$/);
+    };
+
+    // Select matching tab when URL hash changes
+    plugin.selectTabFromHashChange = function() {
+      var hash = window.location.hash.match(/^[^\?]*/)[0],
+          $tab = plugin.matchTab(hash),
+          $panel;
+
+      if ( settings.updateHash ) {
+
+        // If hash directly matches tab
+        if( $tab.length ){
+          skipUpdateToHash = true;
+          plugin.selectTab( $tab );
+
+        } else {
+          $panel = plugin.matchInPanel(hash);
+
+          // If panel contains element matching hash
+          if ( $panel.length ) {
+            hash = '#' + $panel.attr('id');
+            $tab = plugin.matchTab(hash);
+            skipUpdateToHash = true;
+            plugin.selectTab( $tab );
+
+          // If default tab is not active...
+          } else if ( ! $defaultTab.hasClass(settings.tabActiveClass) && ! settings.cycle ) {
+
+            // ...and hash is blank or matches a parent of the tab container or
+            // if the last tab (before the hash updated) was one of the other tabs in this container.
+            if ( hash === '' || plugin.matchTab(lastHash).length || $container.closest(hash).length ) {
+              skipUpdateToHash = true;
+              plugin.selectTab( $defaultTabLink );
+            }
+          }
+        }
+      }
+    };
+
+    // Cycle through tabs
+    plugin.cycleTabs = function(tabNumber){
+      if(settings.cycle){
+        tabNumber = tabNumber % plugin.tabs.length;
+        $tab = $( plugin.tabs[tabNumber] ).children("a").first();
+        skipUpdateToHash = true;
+        plugin.selectTab( $tab, function() {
+          setTimeout(function(){ plugin.cycleTabs(tabNumber + 1); }, settings.cycle);
+        });
+      }
+    };
+
+    // Convenient public methods
+    plugin.publicMethods = {
+      select: function(tabSelector){
+        var $tab;
+
+        // Find tab container that matches selector (like 'li#tab-one' which contains tab link)
+        if ( ($tab = plugin.tabs.filter(tabSelector)).length === 0 ) {
+
+          // Find direct tab link that matches href (like 'a[href="#panel-1"]')
+          if ( ($tab = plugin.tabs.find("a[href='" + tabSelector + "']")).length === 0 ) {
+
+            // Find direct tab link that matches selector (like 'a#tab-1')
+            if ( ($tab = plugin.tabs.find("a" + tabSelector)).length === 0 ) {
+
+              // Find direct tab link that matches data-target (lik 'a[data-target="#panel-1"]')
+              if ( ($tab = plugin.tabs.find("[data-target='" + tabSelector + "']")).length === 0 ) {
+
+                // Find direct tab link that ends in the matching href (like 'a[href$="#panel-1"]', which would also match http://example.com/currentpage/#panel-1)
+                if ( ($tab = plugin.tabs.find("a[href$='" + tabSelector + "']")).length === 0 ) {
+
+                  $.error('Tab \'' + tabSelector + '\' does not exist in tab set');
+                }
+              }
+            }
+          }
+        } else {
+          // Select the child tab link, since the first option finds the tab container (like <li>)
+          $tab = $tab.children("a").first();
+        }
+        plugin.selectTab($tab);
+      }
+    };
+
+    // =============================================================
+    // Private functions
+    // =============================================================
+
+    // Triggers an event on an element and returns the event result
+    var fire = function(obj, name, data) {
+      var event = $.Event(name);
+      obj.trigger(event, data);
+      return event.result !== false;
+    }
+
+    // Add CSS classes to markup (if specified), called by init
+    var addClasses = function() {
+      $container.addClass(settings.containerClass);
+      plugin.tabs.parent().addClass(settings.tabsClass);
+      plugin.tabs.addClass(settings.tabClass);
+      plugin.panels.addClass(settings.panelClass);
+    };
+
+    // Set the default tab, whether from hash (bookmarked) or option,
+    // called by init
+    var setDefaultTab = function(){
+      var hash = window.location.hash.match(/^[^\?]*/)[0],
+          $selectedTab = plugin.matchTab(hash).parent(),
+          $panel;
+
+      // If hash directly matches one of the tabs, active on page-load
+      if( $selectedTab.length === 1 ){
+        $defaultTab = $selectedTab;
+        settings.cycle = false;
+
+      } else {
+        $panel = plugin.matchInPanel(hash);
+
+        // If one of the panels contains the element matching the hash,
+        // make it active on page-load
+        if ( $panel.length ) {
+          hash = '#' + $panel.attr('id');
+          $defaultTab = plugin.matchTab(hash).parent();
+
+        // Otherwise, make the default tab the one that's active on page-load
+        } else {
+          $defaultTab = plugin.tabs.parent().find(settings.defaultTab);
+          if ( $defaultTab.length === 0 ) {
+            $.error("The specified default tab ('" + settings.defaultTab + "') could not be found in the tab set ('" + settings.tabs + "') out of " + plugin.tabs.length + " tabs.");
+          }
+        }
+      }
+
+      $defaultTabLink = $defaultTab.children("a").first();
+
+      activateDefaultTab($selectedTab);
+    };
+
+    // Activate defaultTab (or collapse by default), called by setDefaultTab
+    var activateDefaultTab = function($selectedTab) {
+      var defaultPanel,
+          defaultAjaxUrl;
+
+      if ( settings.collapsible && $selectedTab.length === 0 && settings.collapsedByDefault ) {
+        $defaultTab
+          .addClass(settings.collapsedClass)
+          .children()
+            .addClass(settings.collapsedClass);
+
+      } else {
+
+        defaultPanel = $( $defaultTab.data('easytabs').panel );
+        defaultAjaxUrl = $defaultTab.data('easytabs').ajax;
+
+        if ( defaultAjaxUrl && (!settings.cache || !$defaultTab.data('easytabs').cached) ) {
+          $container.trigger('easytabs:ajax:beforeSend', [$defaultTabLink, defaultPanel]);
+          defaultPanel.load(defaultAjaxUrl, function(response, status, xhr){
+            $defaultTab.data('easytabs').cached = true;
+            $container.trigger('easytabs:ajax:complete', [$defaultTabLink, defaultPanel, response, status, xhr]);
+          });
+        }
+
+        $defaultTab.data('easytabs').panel
+          .show()
+          .addClass(settings.panelActiveClass);
+
+        $defaultTab
+          .addClass(settings.tabActiveClass)
+          .children()
+            .addClass(settings.tabActiveClass);
+      }
+
+      // Fire event when the plugin is initialised
+      $container.trigger("easytabs:initialised", [$defaultTabLink, defaultPanel]);
+    };
+
+    // Bind tab-select funtionality to namespaced click event, called by
+    // init
+    var bindToTabClicks = function() {
+      plugin.tabs.children("a").bind(settings.bind_str, function(e) {
+
+        // Stop cycling when a tab is clicked
+        settings.cycle = false;
+
+        // Hash will be updated when tab is clicked,
+        // don't cause tab to re-select when hash-change event is fired
+        skipUpdateToHash = false;
+
+        // Select the panel for the clicked tab
+        plugin.selectTab( $(this) );
+
+        // Don't follow the link to the anchor
+        e.preventDefault ? e.preventDefault() : e.returnValue = false;
+      });
+    };
+
+    // Activate a given tab/panel, called from plugin.selectTab:
+    //
+    //   * fire `easytabs:before` hook
+    //   * get ajax if new tab is an uncached ajax tab
+    //   * animate out previously-active panel
+    //   * fire `easytabs:midTransition` hook
+    //   * update URL hash
+    //   * animate in newly-active panel
+    //   * update CSS classes for inactive and active tabs/panels
+    //
+    // TODO: This could probably be broken out into many more modular
+    // functions
+    var activateTab = function($clicked, $targetPanel, ajaxUrl, callback) {
+      plugin.panels.stop(true,true);
+
+      if( fire($container,"easytabs:before", [$clicked, $targetPanel, settings]) ){
+        var $visiblePanel = plugin.panels.filter(":visible"),
+            $panelContainer = $targetPanel.parent(),
+            targetHeight,
+            visibleHeight,
+            heightDifference,
+            showPanel,
+            hash = window.location.hash.match(/^[^\?]*/)[0];
+
+        if (settings.animate) {
+          targetHeight = getHeightForHidden($targetPanel);
+          visibleHeight = $visiblePanel.length ? setAndReturnHeight($visiblePanel) : 0;
+          heightDifference = targetHeight - visibleHeight;
+        }
+
+        // Set lastHash to help indicate if defaultTab should be
+        // activated across multiple tab instances.
+        lastHash = hash;
+
+        // TODO: Move this function elsewhere
+        showPanel = function() {
+          // At this point, the previous panel is hidden, and the new one will be selected
+          $container.trigger("easytabs:midTransition", [$clicked, $targetPanel, settings]);
+
+          // Gracefully animate between panels of differing heights, start height change animation *after* panel change if panel needs to contract,
+          // so that there is no chance of making the visible panel overflowing the height of the target panel
+          if (settings.animate && settings.transitionIn == 'fadeIn') {
+            if (heightDifference < 0)
+              $panelContainer.animate({
+                height: $panelContainer.height() + heightDifference
+              }, transitions.halfSpeed ).css({ 'min-height': '' });
+          }
+
+          if ( settings.updateHash && ! skipUpdateToHash ) {
+            //window.location = url.toString().replace((url.pathname + hash), (url.pathname + $clicked.attr("href")));
+            // Not sure why this behaves so differently, but it's more straight forward and seems to have less side-effects
+            window.location.hash = '#' + $targetPanel.attr('id');
+          } else {
+            skipUpdateToHash = false;
+          }
+
+          $targetPanel
+            [transitions.show](transitions.speed, settings.transitionInEasing, function(){
+              $panelContainer.css({height: '', 'min-height': ''}); // After the transition, unset the height
+              $container.trigger("easytabs:after", [$clicked, $targetPanel, settings]);
+              // callback only gets called if selectTab actually does something, since it's inside the if block
+              if(typeof callback == 'function'){
+                callback();
+              }
+          });
+        };
+
+        if ( ajaxUrl && (!settings.cache || !$clicked.parent().data('easytabs').cached) ) {
+          $container.trigger('easytabs:ajax:beforeSend', [$clicked, $targetPanel]);
+          $targetPanel.load(ajaxUrl, function(response, status, xhr){
+            $clicked.parent().data('easytabs').cached = true;
+            $container.trigger('easytabs:ajax:complete', [$clicked, $targetPanel, response, status, xhr]);
+          });
+        }
+
+        // Gracefully animate between panels of differing heights, start height change animation *before* panel change if panel needs to expand,
+        // so that there is no chance of making the target panel overflowing the height of the visible panel
+        if( settings.animate && settings.transitionOut == 'fadeOut' ) {
+          if( heightDifference > 0 ) {
+            $panelContainer.animate({
+              height: ( $panelContainer.height() + heightDifference )
+            }, transitions.halfSpeed );
+          } else {
+            // Prevent height jumping before height transition is triggered at midTransition
+            $panelContainer.css({ 'min-height': $panelContainer.height() });
+          }
+        }
+
+        // Change the active tab *first* to provide immediate feedback when the user clicks
+        plugin.tabs.filter("." + settings.tabActiveClass).removeClass(settings.tabActiveClass).children().removeClass(settings.tabActiveClass);
+        plugin.tabs.filter("." + settings.collapsedClass).removeClass(settings.collapsedClass).children().removeClass(settings.collapsedClass);
+        $clicked.parent().addClass(settings.tabActiveClass).children().addClass(settings.tabActiveClass);
+
+        plugin.panels.filter("." + settings.panelActiveClass).removeClass(settings.panelActiveClass);
+        $targetPanel.addClass(settings.panelActiveClass);
+
+        if( $visiblePanel.length ) {
+          $visiblePanel
+            [transitions.hide](transitions.speed, settings.transitionOutEasing, showPanel);
+        } else {
+          $targetPanel
+            [transitions.uncollapse](transitions.speed, settings.transitionUncollapseEasing, showPanel);
+        }
+      }
+    };
+
+    // Get heights of panels to enable animation between panels of
+    // differing heights, called by activateTab
+    var getHeightForHidden = function($targetPanel){
+
+      if ( $targetPanel.data('easytabs') && $targetPanel.data('easytabs').lastHeight ) {
+        return $targetPanel.data('easytabs').lastHeight;
+      }
+
+      // this is the only property easytabs changes, so we need to grab its value on each tab change
+      var display = $targetPanel.css('display'),
+          outerCloak,
+          height;
+
+      // Workaround with wrapping height, because firefox returns wrong
+      // height if element itself has absolute positioning.
+      // but try/catch block needed for IE7 and IE8 because they throw
+      // an "Unspecified error" when trying to create an element
+      // with the css position set.
+      try {
+        outerCloak = $('<div></div>', {'position': 'absolute', 'visibility': 'hidden', 'overflow': 'hidden'});
+      } catch (e) {
+        outerCloak = $('<div></div>', {'visibility': 'hidden', 'overflow': 'hidden'});
+      }
+      height = $targetPanel
+        .wrap(outerCloak)
+        .css({'position':'relative','visibility':'hidden','display':'block'})
+        .outerHeight();
+
+      $targetPanel.unwrap();
+
+      // Return element to previous state
+      $targetPanel.css({
+        position: $targetPanel.data('easytabs').position,
+        visibility: $targetPanel.data('easytabs').visibility,
+        display: display
+      });
+
+      // Cache height
+      $targetPanel.data('easytabs').lastHeight = height;
+
+      return height;
+    };
+
+    // Since the height of the visible panel may have been manipulated due to interaction,
+    // we want to re-cache the visible height on each tab change, called
+    // by activateTab
+    var setAndReturnHeight = function($visiblePanel) {
+      var height = $visiblePanel.outerHeight();
+
+      if( $visiblePanel.data('easytabs') ) {
+        $visiblePanel.data('easytabs').lastHeight = height;
+      } else {
+        $visiblePanel.data('easytabs', {lastHeight: height});
+      }
+      return height;
+    };
+
+    // Setup hash-change callback for forward- and back-button
+    // functionality, called by init
+    var initHashChange = function(){
+
+      // enabling back-button with jquery.hashchange plugin
+      // http://benalman.com/projects/jquery-hashchange-plugin/
+      if(typeof $(window).hashchange === 'function'){
+        $(window).hashchange( function(){
+          plugin.selectTabFromHashChange();
+        });
+      } else if ($.address && typeof $.address.change === 'function') { // back-button with jquery.address plugin http://www.asual.com/jquery/address/docs/
+        $.address.change( function(){
+          plugin.selectTabFromHashChange();
+        });
+      }
+    };
+
+    // Begin cycling if set in options, called by init
+    var initCycle = function(){
+      var tabNumber;
+      if (settings.cycle) {
+        tabNumber = plugin.tabs.index($defaultTab);
+        setTimeout( function(){ plugin.cycleTabs(tabNumber + 1); }, settings.cycle);
+      }
+    };
+
+
+    plugin.init();
+
+  };
+
+  $.fn.easytabs = function(options) {
+    var args = arguments;
+
+    return this.each(function() {
+      var $this = $(this),
+          plugin = $this.data('easytabs');
+
+      // Initialization was called with $(el).easytabs( { options } );
+      if (undefined === plugin) {
+        plugin = new $.easytabs(this, options);
+        $this.data('easytabs', plugin);
+      }
+
+      // User called public method
+      if ( plugin.publicMethods[options] ){
+        return plugin.publicMethods[options](Array.prototype.slice.call( args, 1 ));
+      }
+    });
+  };
+
+})(jQuery);

--- a/common/static/js/vendor/jquery.hashchange.js
+++ b/common/static/js/vendor/jquery.hashchange.js
@@ -1,0 +1,390 @@
+/*!
+ * jQuery hashchange event - v1.3 - 7/21/2010
+ * http://benalman.com/projects/jquery-hashchange-plugin/
+ * 
+ * Copyright (c) 2010 "Cowboy" Ben Alman
+ * Dual licensed under the MIT and GPL licenses.
+ * http://benalman.com/about/license/
+ */
+
+// Script: jQuery hashchange event
+//
+// *Version: 1.3, Last updated: 7/21/2010*
+// 
+// Project Home - http://benalman.com/projects/jquery-hashchange-plugin/
+// GitHub       - http://github.com/cowboy/jquery-hashchange/
+// Source       - http://github.com/cowboy/jquery-hashchange/raw/master/jquery.ba-hashchange.js
+// (Minified)   - http://github.com/cowboy/jquery-hashchange/raw/master/jquery.ba-hashchange.min.js (0.8kb gzipped)
+// 
+// About: License
+// 
+// Copyright (c) 2010 "Cowboy" Ben Alman,
+// Dual licensed under the MIT and GPL licenses.
+// http://benalman.com/about/license/
+// 
+// About: Examples
+// 
+// These working examples, complete with fully commented code, illustrate a few
+// ways in which this plugin can be used.
+// 
+// hashchange event - http://benalman.com/code/projects/jquery-hashchange/examples/hashchange/
+// document.domain - http://benalman.com/code/projects/jquery-hashchange/examples/document_domain/
+// 
+// About: Support and Testing
+// 
+// Information about what version or versions of jQuery this plugin has been
+// tested with, what browsers it has been tested in, and where the unit tests
+// reside (so you can test it yourself).
+// 
+// jQuery Versions - 1.2.6, 1.3.2, 1.4.1, 1.4.2
+// Browsers Tested - Internet Explorer 6-8, Firefox 2-4, Chrome 5-6, Safari 3.2-5,
+//                   Opera 9.6-10.60, iPhone 3.1, Android 1.6-2.2, BlackBerry 4.6-5.
+// Unit Tests      - http://benalman.com/code/projects/jquery-hashchange/unit/
+// 
+// About: Known issues
+// 
+// While this jQuery hashchange event implementation is quite stable and
+// robust, there are a few unfortunate browser bugs surrounding expected
+// hashchange event-based behaviors, independent of any JavaScript
+// window.onhashchange abstraction. See the following examples for more
+// information:
+// 
+// Chrome: Back Button - http://benalman.com/code/projects/jquery-hashchange/examples/bug-chrome-back-button/
+// Firefox: Remote XMLHttpRequest - http://benalman.com/code/projects/jquery-hashchange/examples/bug-firefox-remote-xhr/
+// WebKit: Back Button in an Iframe - http://benalman.com/code/projects/jquery-hashchange/examples/bug-webkit-hash-iframe/
+// Safari: Back Button from a different domain - http://benalman.com/code/projects/jquery-hashchange/examples/bug-safari-back-from-diff-domain/
+// 
+// Also note that should a browser natively support the window.onhashchange 
+// event, but not report that it does, the fallback polling loop will be used.
+// 
+// About: Release History
+// 
+// 1.3   - (7/21/2010) Reorganized IE6/7 Iframe code to make it more
+//         "removable" for mobile-only development. Added IE6/7 document.title
+//         support. Attempted to make Iframe as hidden as possible by using
+//         techniques from http://www.paciellogroup.com/blog/?p=604. Added 
+//         support for the "shortcut" format $(window).hashchange( fn ) and
+//         $(window).hashchange() like jQuery provides for built-in events.
+//         Renamed jQuery.hashchangeDelay to <jQuery.fn.hashchange.delay> and
+//         lowered its default value to 50. Added <jQuery.fn.hashchange.domain>
+//         and <jQuery.fn.hashchange.src> properties plus document-domain.html
+//         file to address access denied issues when setting document.domain in
+//         IE6/7.
+// 1.2   - (2/11/2010) Fixed a bug where coming back to a page using this plugin
+//         from a page on another domain would cause an error in Safari 4. Also,
+//         IE6/7 Iframe is now inserted after the body (this actually works),
+//         which prevents the page from scrolling when the event is first bound.
+//         Event can also now be bound before DOM ready, but it won't be usable
+//         before then in IE6/7.
+// 1.1   - (1/21/2010) Incorporated document.documentMode test to fix IE8 bug
+//         where browser version is incorrectly reported as 8.0, despite
+//         inclusion of the X-UA-Compatible IE=EmulateIE7 meta tag.
+// 1.0   - (1/9/2010) Initial Release. Broke out the jQuery BBQ event.special
+//         window.onhashchange functionality into a separate plugin for users
+//         who want just the basic event & back button support, without all the
+//         extra awesomeness that BBQ provides. This plugin will be included as
+//         part of jQuery BBQ, but also be available separately.
+
+(function($,window,undefined){
+  '$:nomunge'; // Used by YUI compressor.
+  
+  // Reused string.
+  var str_hashchange = 'hashchange',
+    
+    // Method / object references.
+    doc = document,
+    fake_onhashchange,
+    special = $.event.special,
+    
+    // Does the browser support window.onhashchange? Note that IE8 running in
+    // IE7 compatibility mode reports true for 'onhashchange' in window, even
+    // though the event isn't supported, so also test document.documentMode.
+    doc_mode = doc.documentMode,
+    supports_onhashchange = 'on' + str_hashchange in window && ( doc_mode === undefined || doc_mode > 7 );
+  
+  // Get location.hash (or what you'd expect location.hash to be) sans any
+  // leading #. Thanks for making this necessary, Firefox!
+  function get_fragment( url ) {
+    url = url || location.href;
+    return '#' + url.replace( /^[^#]*#?(.*)$/, '$1' );
+  };
+  
+  // Method: jQuery.fn.hashchange
+  // 
+  // Bind a handler to the window.onhashchange event or trigger all bound
+  // window.onhashchange event handlers. This behavior is consistent with
+  // jQuery's built-in event handlers.
+  // 
+  // Usage:
+  // 
+  // > jQuery(window).hashchange( [ handler ] );
+  // 
+  // Arguments:
+  // 
+  //  handler - (Function) Optional handler to be bound to the hashchange
+  //    event. This is a "shortcut" for the more verbose form:
+  //    jQuery(window).bind( 'hashchange', handler ). If handler is omitted,
+  //    all bound window.onhashchange event handlers will be triggered. This
+  //    is a shortcut for the more verbose
+  //    jQuery(window).trigger( 'hashchange' ). These forms are described in
+  //    the <hashchange event> section.
+  // 
+  // Returns:
+  // 
+  //  (jQuery) The initial jQuery collection of elements.
+  
+  // Allow the "shortcut" format $(elem).hashchange( fn ) for binding and
+  // $(elem).hashchange() for triggering, like jQuery does for built-in events.
+  $.fn[ str_hashchange ] = function( fn ) {
+    return fn ? this.bind( str_hashchange, fn ) : this.trigger( str_hashchange );
+  };
+  
+  // Property: jQuery.fn.hashchange.delay
+  // 
+  // The numeric interval (in milliseconds) at which the <hashchange event>
+  // polling loop executes. Defaults to 50.
+  
+  // Property: jQuery.fn.hashchange.domain
+  // 
+  // If you're setting document.domain in your JavaScript, and you want hash
+  // history to work in IE6/7, not only must this property be set, but you must
+  // also set document.domain BEFORE jQuery is loaded into the page. This
+  // property is only applicable if you are supporting IE6/7 (or IE8 operating
+  // in "IE7 compatibility" mode).
+  // 
+  // In addition, the <jQuery.fn.hashchange.src> property must be set to the
+  // path of the included "document-domain.html" file, which can be renamed or
+  // modified if necessary (note that the document.domain specified must be the
+  // same in both your main JavaScript as well as in this file).
+  // 
+  // Usage:
+  // 
+  // jQuery.fn.hashchange.domain = document.domain;
+  
+  // Property: jQuery.fn.hashchange.src
+  // 
+  // If, for some reason, you need to specify an Iframe src file (for example,
+  // when setting document.domain as in <jQuery.fn.hashchange.domain>), you can
+  // do so using this property. Note that when using this property, history
+  // won't be recorded in IE6/7 until the Iframe src file loads. This property
+  // is only applicable if you are supporting IE6/7 (or IE8 operating in "IE7
+  // compatibility" mode).
+  // 
+  // Usage:
+  // 
+  // jQuery.fn.hashchange.src = 'path/to/file.html';
+  
+  $.fn[ str_hashchange ].delay = 50;
+  /*
+  $.fn[ str_hashchange ].domain = null;
+  $.fn[ str_hashchange ].src = null;
+  */
+  
+  // Event: hashchange event
+  // 
+  // Fired when location.hash changes. In browsers that support it, the native
+  // HTML5 window.onhashchange event is used, otherwise a polling loop is
+  // initialized, running every <jQuery.fn.hashchange.delay> milliseconds to
+  // see if the hash has changed. In IE6/7 (and IE8 operating in "IE7
+  // compatibility" mode), a hidden Iframe is created to allow the back button
+  // and hash-based history to work.
+  // 
+  // Usage as described in <jQuery.fn.hashchange>:
+  // 
+  // > // Bind an event handler.
+  // > jQuery(window).hashchange( function(e) {
+  // >   var hash = location.hash;
+  // >   ...
+  // > });
+  // > 
+  // > // Manually trigger the event handler.
+  // > jQuery(window).hashchange();
+  // 
+  // A more verbose usage that allows for event namespacing:
+  // 
+  // > // Bind an event handler.
+  // > jQuery(window).bind( 'hashchange', function(e) {
+  // >   var hash = location.hash;
+  // >   ...
+  // > });
+  // > 
+  // > // Manually trigger the event handler.
+  // > jQuery(window).trigger( 'hashchange' );
+  // 
+  // Additional Notes:
+  // 
+  // * The polling loop and Iframe are not created until at least one handler
+  //   is actually bound to the 'hashchange' event.
+  // * If you need the bound handler(s) to execute immediately, in cases where
+  //   a location.hash exists on page load, via bookmark or page refresh for
+  //   example, use jQuery(window).hashchange() or the more verbose 
+  //   jQuery(window).trigger( 'hashchange' ).
+  // * The event can be bound before DOM ready, but since it won't be usable
+  //   before then in IE6/7 (due to the necessary Iframe), recommended usage is
+  //   to bind it inside a DOM ready handler.
+  
+  // Override existing $.event.special.hashchange methods (allowing this plugin
+  // to be defined after jQuery BBQ in BBQ's source code).
+  special[ str_hashchange ] = $.extend( special[ str_hashchange ], {
+    
+    // Called only when the first 'hashchange' event is bound to window.
+    setup: function() {
+      // If window.onhashchange is supported natively, there's nothing to do..
+      if ( supports_onhashchange ) { return false; }
+      
+      // Otherwise, we need to create our own. And we don't want to call this
+      // until the user binds to the event, just in case they never do, since it
+      // will create a polling loop and possibly even a hidden Iframe.
+      $( fake_onhashchange.start );
+    },
+    
+    // Called only when the last 'hashchange' event is unbound from window.
+    teardown: function() {
+      // If window.onhashchange is supported natively, there's nothing to do..
+      if ( supports_onhashchange ) { return false; }
+      
+      // Otherwise, we need to stop ours (if possible).
+      $( fake_onhashchange.stop );
+    }
+    
+  });
+  
+  // fake_onhashchange does all the work of triggering the window.onhashchange
+  // event for browsers that don't natively support it, including creating a
+  // polling loop to watch for hash changes and in IE 6/7 creating a hidden
+  // Iframe to enable back and forward.
+  fake_onhashchange = (function(){
+    var self = {},
+      timeout_id,
+      
+      // Remember the initial hash so it doesn't get triggered immediately.
+      last_hash = get_fragment(),
+      
+      fn_retval = function(val){ return val; },
+      history_set = fn_retval,
+      history_get = fn_retval;
+    
+    // Start the polling loop.
+    self.start = function() {
+      timeout_id || poll();
+    };
+    
+    // Stop the polling loop.
+    self.stop = function() {
+      timeout_id && clearTimeout( timeout_id );
+      timeout_id = undefined;
+    };
+    
+    // This polling loop checks every $.fn.hashchange.delay milliseconds to see
+    // if location.hash has changed, and triggers the 'hashchange' event on
+    // window when necessary.
+    function poll() {
+      var hash = get_fragment(),
+        history_hash = history_get( last_hash );
+      
+      if ( hash !== last_hash ) {
+        history_set( last_hash = hash, history_hash );
+        
+        $(window).trigger( str_hashchange );
+        
+      } else if ( history_hash !== last_hash ) {
+        location.href = location.href.replace( /#.*/, '' ) + history_hash;
+      }
+      
+      timeout_id = setTimeout( poll, $.fn[ str_hashchange ].delay );
+    };
+    
+    // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+    // vvvvvvvvvvvvvvvvvvv REMOVE IF NOT SUPPORTING IE6/7/8 vvvvvvvvvvvvvvvvvvv
+    // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+    $.browser.msie && !supports_onhashchange && (function(){
+      // Not only do IE6/7 need the "magical" Iframe treatment, but so does IE8
+      // when running in "IE7 compatibility" mode.
+      
+      var iframe,
+        iframe_src;
+      
+      // When the event is bound and polling starts in IE 6/7, create a hidden
+      // Iframe for history handling.
+      self.start = function(){
+        if ( !iframe ) {
+          iframe_src = $.fn[ str_hashchange ].src;
+          iframe_src = iframe_src && iframe_src + get_fragment();
+          
+          // Create hidden Iframe. Attempt to make Iframe as hidden as possible
+          // by using techniques from http://www.paciellogroup.com/blog/?p=604.
+          iframe = $('<iframe tabindex="-1" title="empty"/>').hide()
+            
+            // When Iframe has completely loaded, initialize the history and
+            // start polling.
+            .one( 'load', function(){
+              iframe_src || history_set( get_fragment() );
+              poll();
+            })
+            
+            // Load Iframe src if specified, otherwise nothing.
+            .attr( 'src', iframe_src || 'javascript:0' )
+            
+            // Append Iframe after the end of the body to prevent unnecessary
+            // initial page scrolling (yes, this works).
+            .insertAfter( 'body' )[0].contentWindow;
+          
+          // Whenever `document.title` changes, update the Iframe's title to
+          // prettify the back/next history menu entries. Since IE sometimes
+          // errors with "Unspecified error" the very first time this is set
+          // (yes, very useful) wrap this with a try/catch block.
+          doc.onpropertychange = function(){
+            try {
+              if ( event.propertyName === 'title' ) {
+                iframe.document.title = doc.title;
+              }
+            } catch(e) {}
+          };
+          
+        }
+      };
+      
+      // Override the "stop" method since an IE6/7 Iframe was created. Even
+      // if there are no longer any bound event handlers, the polling loop
+      // is still necessary for back/next to work at all!
+      self.stop = fn_retval;
+      
+      // Get history by looking at the hidden Iframe's location.hash.
+      history_get = function() {
+        return get_fragment( iframe.location.href );
+      };
+      
+      // Set a new history item by opening and then closing the Iframe
+      // document, *then* setting its location.hash. If document.domain has
+      // been set, update that as well.
+      history_set = function( hash, history_hash ) {
+        var iframe_doc = iframe.document,
+          domain = $.fn[ str_hashchange ].domain;
+        
+        if ( hash !== history_hash ) {
+          // Update Iframe with any initial `document.title` that might be set.
+          iframe_doc.title = doc.title;
+          
+          // Opening the Iframe's document after it has been closed is what
+          // actually adds a history entry.
+          iframe_doc.open();
+          
+          // Set document.domain for the Iframe document as well, if necessary.
+          domain && iframe_doc.write( '<script>document.domain="' + domain + '"</script>' );
+          
+          iframe_doc.close();
+          
+          // Update the Iframe's hash, for great justice.
+          iframe.location.hash = hash;
+        }
+      };
+      
+    })();
+    // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    // ^^^^^^^^^^^^^^^^^^^ REMOVE IF NOT SUPPORTING IE6/7/8 ^^^^^^^^^^^^^^^^^^^
+    // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    
+    return self;
+  })();
+  
+})(jQuery,this);

--- a/common/static/js/vendor/jquery.scrollTo.js
+++ b/common/static/js/vendor/jquery.scrollTo.js
@@ -1,0 +1,210 @@
+/*!
+ * jQuery.scrollTo
+ * Copyright (c) 2007-2015 Ariel Flesler - aflesler<a>gmail<d>com | http://flesler.blogspot.com
+ * Licensed under MIT
+ * http://flesler.blogspot.com/2007/10/jqueryscrollto.html
+ * @projectDescription Lightweight, cross-browser and highly customizable animated scrolling with jQuery
+ * @author Ariel Flesler
+ * @version 2.1.2
+ */
+;(function(factory) {
+	'use strict';
+	if (typeof define === 'function' && define.amd) {
+		// AMD
+		define(['jquery'], factory);
+	} else if (typeof module !== 'undefined' && module.exports) {
+		// CommonJS
+		module.exports = factory(require('jquery'));
+	} else {
+		// Global
+		factory(jQuery);
+	}
+})(function($) {
+	'use strict';
+
+	var $scrollTo = $.scrollTo = function(target, duration, settings) {
+		return $(window).scrollTo(target, duration, settings);
+	};
+
+	$scrollTo.defaults = {
+		axis:'xy',
+		duration: 0,
+		limit:true
+	};
+
+	function isWin(elem) {
+		return !elem.nodeName ||
+			$.inArray(elem.nodeName.toLowerCase(), ['iframe','#document','html','body']) !== -1;
+	}		
+
+	$.fn.scrollTo = function(target, duration, settings) {
+		if (typeof duration === 'object') {
+			settings = duration;
+			duration = 0;
+		}
+		if (typeof settings === 'function') {
+			settings = { onAfter:settings };
+		}
+		if (target === 'max') {
+			target = 9e9;
+		}
+
+		settings = $.extend({}, $scrollTo.defaults, settings);
+		// Speed is still recognized for backwards compatibility
+		duration = duration || settings.duration;
+		// Make sure the settings are given right
+		var queue = settings.queue && settings.axis.length > 1;
+		if (queue) {
+			// Let's keep the overall duration
+			duration /= 2;
+		}
+		settings.offset = both(settings.offset);
+		settings.over = both(settings.over);
+
+		return this.each(function() {
+			// Null target yields nothing, just like jQuery does
+			if (target === null) return;
+
+			var win = isWin(this),
+				elem = win ? this.contentWindow || window : this,
+				$elem = $(elem),
+				targ = target, 
+				attr = {},
+				toff;
+
+			switch (typeof targ) {
+				// A number will pass the regex
+				case 'number':
+				case 'string':
+					if (/^([+-]=?)?\d+(\.\d+)?(px|%)?$/.test(targ)) {
+						targ = both(targ);
+						// We are done
+						break;
+					}
+					// Relative/Absolute selector
+					targ = win ? $(targ) : $(targ, elem);
+					/* falls through */
+				case 'object':
+					if (targ.length === 0) return;
+					// DOMElement / jQuery
+					if (targ.is || targ.style) {
+						// Get the real position of the target
+						toff = (targ = $(targ)).offset();
+					}
+			}
+
+			var offset = $.isFunction(settings.offset) && settings.offset(elem, targ) || settings.offset;
+
+			$.each(settings.axis.split(''), function(i, axis) {
+				var Pos	= axis === 'x' ? 'Left' : 'Top',
+					pos = Pos.toLowerCase(),
+					key = 'scroll' + Pos,
+					prev = $elem[key](),
+					max = $scrollTo.max(elem, axis);
+
+				if (toff) {// jQuery / DOMElement
+					attr[key] = toff[pos] + (win ? 0 : prev - $elem.offset()[pos]);
+
+					// If it's a dom element, reduce the margin
+					if (settings.margin) {
+						attr[key] -= parseInt(targ.css('margin'+Pos), 10) || 0;
+						attr[key] -= parseInt(targ.css('border'+Pos+'Width'), 10) || 0;
+					}
+
+					attr[key] += offset[pos] || 0;
+
+					if (settings.over[pos]) {
+						// Scroll to a fraction of its width/height
+						attr[key] += targ[axis === 'x'?'width':'height']() * settings.over[pos];
+					}
+				} else {
+					var val = targ[pos];
+					// Handle percentage values
+					attr[key] = val.slice && val.slice(-1) === '%' ?
+						parseFloat(val) / 100 * max
+						: val;
+				}
+
+				// Number or 'number'
+				if (settings.limit && /^\d+$/.test(attr[key])) {
+					// Check the limits
+					attr[key] = attr[key] <= 0 ? 0 : Math.min(attr[key], max);
+				}
+
+				// Don't waste time animating, if there's no need.
+				if (!i && settings.axis.length > 1) {
+					if (prev === attr[key]) {
+						// No animation needed
+						attr = {};
+					} else if (queue) {
+						// Intermediate animation
+						animate(settings.onAfterFirst);
+						// Don't animate this axis again in the next iteration.
+						attr = {};
+					}
+				}
+			});
+
+			animate(settings.onAfter);
+
+			function animate(callback) {
+				var opts = $.extend({}, settings, {
+					// The queue setting conflicts with animate()
+					// Force it to always be true
+					queue: true,
+					duration: duration,
+					complete: callback && function() {
+						callback.call(elem, targ, settings);
+					}
+				});
+				$elem.animate(attr, opts);
+			}
+		});
+	};
+
+	// Max scrolling position, works on quirks mode
+	// It only fails (not too badly) on IE, quirks mode.
+	$scrollTo.max = function(elem, axis) {
+		var Dim = axis === 'x' ? 'Width' : 'Height',
+			scroll = 'scroll'+Dim;
+
+		if (!isWin(elem))
+			return elem[scroll] - $(elem)[Dim.toLowerCase()]();
+
+		var size = 'client' + Dim,
+			doc = elem.ownerDocument || elem.document,
+			html = doc.documentElement,
+			body = doc.body;
+
+		return Math.max(html[scroll], body[scroll]) - Math.min(html[size], body[size]);
+	};
+
+	function both(val) {
+		return $.isFunction(val) || $.isPlainObject(val) ? val : { top:val, left:val };
+	}
+
+	// Add special hooks so that window scroll properties can be animated
+	$.Tween.propHooks.scrollLeft = 
+	$.Tween.propHooks.scrollTop = {
+		get: function(t) {
+			return $(t.elem)[t.prop]();
+		},
+		set: function(t) {
+			var curr = this.get(t);
+			// If interrupt is true and user scrolled, stop animating
+			if (t.options.interrupt && t._last && t._last !== curr) {
+				return $(t.elem).stop();
+			}
+			var next = Math.round(t.now);
+			// Don't waste CPU
+			// Browsers don't render floating point scroll
+			if (curr !== next) {
+				$(t.elem)[t.prop](next);
+				t._last = this.get(t);
+			}
+		}
+	};
+
+	// AMD requirement
+	return $scrollTo;
+});


### PR DESCRIPTION
Even though we've created a new key terms glossary using the mfe frontend for glossary, we're including these libraries here to make sure the old Glossary jQuery page loads.