### PR TITLE
Add CMS management command to update course advanced settings in bulk.

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/set_advanced_fields_all_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/set_advanced_fields_all_courses.py
@@ -1,0 +1,223 @@
+"""
+Script for updating an Advanced Setting across all courses.
+
+This script is setup to only update the `modulestore` courses.
+"""
+
+import copy
+import json
+import logging
+
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
+from django.core.management import CommandError
+from django.core.management.base import BaseCommand
+
+from .utils import user_from_str
+from ....contentstore.views.course import update_course_advanced_settings
+
+from opaque_keys.edx.keys import CourseKey
+from xmodule.modulestore.django import modulestore
+
+logger = logging.getLogger(__name__)
+
+class Command(BaseCommand):
+    """
+    Duraration:
+        When running this against all courses it may take considerable more time because
+        the course publishes out. This is due to the `update_course_advanced_settings` call.
+
+    Invoke with:
+
+        # Single Course
+        # Set the following advanced settings:
+        # `invitation_only` to `true`
+        # `catalog_visilibilty` to `about`
+        python manage.py cms --settings=devstack_docker set_advanced_fields_all_courses \
+        --fields_json '{"invitation_only": {"value": "true"}}' --user edx@example.com --course course-v1:ORG+COURSENUMBER+COURSERUN --force-update-catalog-visibility-about
+
+        # All Courses
+        # Set the following advanced settings:
+        # `invitation_only` to `true`
+        # `catalog_visilibilty` to `about`
+        # `cerfificate_display_behavior` to `early_no_info`
+        python manage.py cms --settings=devstack_docker set_advanced_fields_all_courses \
+        --fields_json '{"invitation_only": {"value": "true"}, "certificates_display_behavior": {"value": "early_no_info"}}' --user edx@example.com --course course-v1:ORG+COURSENUMBER+COURSERUN --force-update-catalog-visibility-about
+
+        # All Courses
+        # Set the following advanced settings:
+        # `catalog_visilibilty` to `about`
+        python manage.py cms --settings=devstack_docker set_advanced_fields_all_courses \
+        --fields_json '{}' --user edx@example.com --course course-v1:ORG+COURSENUMBER+COURSERUN --force-update-catalog-visibility-about
+    """
+    help = 'Set an advanced settings for all courses based on a json list of fields.'
+
+    fields_json_help = '\
+        Need to have a json list of "field_name": "<new value>" \
+        { \
+            "catalog_visibility": { \
+                "value": "about" \
+            }, \
+            "certificates_display_behavior": { \
+                "value": "early_no_info" \
+            }, \
+            "invitation_only": { \
+                "value": "true" \
+            } \
+        }'
+    user_help = '--user <email> required, needs to be a staff member'
+    course_help = '--course <id> required, e.g. course-v1:ORG+COURSENUMBER+COURSERUN'
+    force_update_catalog_visibility_about_help = '--force-update-catalog-visibility-about, To fix `There was an error loading this course` error when loading MFE learning this forces `catalog_visibility` from `none` to `about`.'
+
+    _force_update_catalog_visibility_about = False
+    _updated_catalog_visilibity_about = []
+
+    def add_arguments(self, parser):
+        parser.add_argument('--fields_json',
+                            dest='fields_json',
+                            default=False,
+                            required=True,
+                            help=self.fields_json_help)
+        parser.add_argument('--user',
+                            dest='user_email',
+                            default=False,
+                            required=True,
+                            help=self.user_help)
+        parser.add_argument('--course',
+                            dest='course_id',
+                            default=False,
+                            required=False,
+                            help=self.course_help)
+        parser.add_argument('--force-update-catalog-visibility-about',
+                            dest='force_update_catalog_visibility_about',
+                            action='store_true',
+                            help=self.force_update_catalog_visibility_about_help)
+
+    def handle(self, *args, **options):
+        """
+        Execute the command
+        """
+        self._force_update_catalog_visibility_about = options.get('force_update_catalog_visibility_about', False)
+        try:
+            update_fields = json.loads(options["fields_json"])
+        except ValueError:
+            raise CommandError("Invalid JSON object")  # lint-amnesty, pylint: 
+
+        # Update course(s) to push out `fields_json` of advanced setting changes.
+        self._set_courses_advanced_fields(update_fields, options['user_email'], options['course_id'])
+
+
+    def _set_courses_advanced_fields(self, update_fields, user_email, course_id):
+        """
+        Export all courses to target directory and return the list of courses which failed to export
+        """
+
+        try:
+            user = user_from_str(user_email)
+        except User.DoesNotExist:
+            logger.warning(user_email + " user does not exist")  # lint-amnesty, pylint: disable=logging-not-lazy
+            logger.warning("Can't update fields")
+            return
+
+        # Single Course
+        if course_id:        
+            course_module = modulestore().get_course(CourseKey.from_string(course_id))
+            
+            revised_update_fields = self._force_catalog_visibility_about(update_fields, course_module)
+            
+            print(f"Applying revised_update_fields = {revised_update_fields} to course {course_id} using `{user}` user.\n")
+            print("=" * 80)
+            updated_data = update_course_advanced_settings(course_module, revised_update_fields, user)
+
+            print("=" * 80)
+            
+            for field in revised_update_fields.keys():
+                print(f"Updated data for course advanced settings `{field}` = {updated_data[field]}")
+                print("=" * 80)
+
+        # All Courses
+        else:
+            courses = modulestore().get_courses()
+            course_ids = [x.id for x in courses]
+            
+            failed_update_advanced_fields_courses = []
+
+            for course_id in course_ids:
+                try:
+                    course_module = modulestore().get_course(CourseKey.from_string(str(course_id)))
+
+                    revised_update_fields = self._force_catalog_visibility_about(update_fields, course_module)
+
+                    print(f"Applying revised_update_fields = {revised_update_fields} to course {course_id} using `{user}` user.\n")
+                    updated_data = update_course_advanced_settings(course_module, revised_update_fields, user)
+
+                    print("=" * 80)
+                    
+                    for field in revised_update_fields.keys():
+                        print(f"Updated data for course advanced settings `{field}` = {updated_data[field]}")
+                        print("=" * 80)
+                                        
+                except Exception as err:  # pylint: disable=broad-except
+                    failed_update_advanced_fields_courses.append(str(course_id))
+                    print("=" * 30 + f"> Oops, failed to update fields for {course_id}")
+                    print("Error:")
+                    print(err)
+
+            print("=" * 80)
+            print("=" * 30 + "> Reset fields summary")
+            print(f"Total number of courses to update advanced fields: {len(courses)}")
+            print(f"Total number of courses which failed to update advanced fields: {len(failed_update_advanced_fields_courses)}")
+            print("List of updated advanced fields failed courses ids:")
+            print("\n".join(failed_update_advanced_fields_courses))
+
+            if self._force_update_catalog_visibility_about:
+                print("List of updated courses ids `catalog_visibility` changes from `none` to `about`:")
+                print("\n".join(self._updated_catalog_visilibity_about))
+            
+            print("=" * 80)
+
+
+    def _force_catalog_visibility_about(self, update_fields, course_module):
+        """
+        Explicitly update `catalog_visilibility` = `none` to `about` to fix issue with
+        `There was an error loading this course`.
+        Details: https://discuss.openedx.org/t/how-to-programmatically-set-a-course-advanced-fields/8901/3
+
+        Return fields to update with the following settings added.
+
+        {
+            "catalog_visibility": {
+                "value": "about"
+            }
+        }
+        """
+
+        revised_update_fields = copy.deepcopy(update_fields)
+
+        if hasattr(course_module, 'catalog_visibility') and getattr(course_module, 'catalog_visibility') == 'none':
+            print(f"Found course `{course_module.id}` that has `catalog_visibility` set to `none`.")
+
+            # Set `catalog_visibility`=`none` to `about` in `revised_update_fields` values.
+            if self._force_update_catalog_visibility_about:
+                try:
+                    if hasattr(revised_update_fields, 'catalog_visibility'):
+                        revised_update_fields['catalog_visibility']['value'] = 'about'
+                    else:
+                        revised_update_fields.update({
+                            "catalog_visibility": {
+                                "value": "about"
+                            }
+                        })
+                except KeyError:
+                    raise CommandError("Value error missing in `catalog_visibility` JSON object")  # lint-amnesty, pylint: disable=raise-missing-from
+
+                print(
+                    "Added { 'catalog_visibility': { 'value': 'about' } } to `revised_update_fields`, "
+                    "to prevent `There was an error loading this course` in MFE Learning."
+                )
+
+                # Keep track of the courses that have changed `catalog_visibility` values from `none` to `about`
+                self._updated_catalog_visilibity_about.append(str(course_module.id))
+
+        return revised_update_fields
+
+    


### PR DESCRIPTION
## Description

Needed a way to set course advanced fields through the Django management command line. Instead of call the REST PATCH endpoint here cms/djangoapps/contentstore/rest_api/v0/views/advanced_settings.py we utilized the `update_course_advanced_settings` method here  cms/djangoapps/contentstore/views/course.py to pass JSON override values for one or more courses.

A `--force-update-catalog-visibility-about` command option was added to include advanced setting. When upgrading from an older release to `Maple` we had this `catalog_visibility` set to `none` which produced the `There was an error loading this course` message when viewing the course MFE Learning frontend. It was necessary to make sure these courses didn't have the `none` value and received `about` or `both` settings to have the page load properly. This command sets the value to `about` to prevent the course from uploading to the `course-discovery` service and out to the marketing frontend.
```
{
    "catalog_visibility": {
        "value": "about"
    }
}
```

## Supporting information

We’re running into this issue mentioned above for students to be able to view the MFE learning page when Course Visibility in Catalog is set to none. The students receive the `There was an error loading this course.` message and nothing loads on the Course Home page. Also the LMS log files indicate no error messages so we were lucky to find this discussion article.

Reference: https://discuss.openedx.org/t/how-to-programmatically-set-a-course-advanced-fields/8901

## Testing instructions

When upgrading from prior release to `Maple` we had several courses with `course_visibility` set to `none` value. With this setting we traversed to the MFE Learning frontend and saw error message with `There was an error loading this course.` and a HTTP 404 response from an EdX API endpoint in the JavaScript console was indicated.

So to regenerate this error just set the `CMS > Advanced Settings > Catalog Visibility` value to `none`.

![image](https://user-images.githubusercontent.com/5641338/207708976-8cb10613-aa01-4770-82fe-9131f097c7fd.png)

HTTP 404 Response was at this address.
https://{{ LMS_HOST }}/api/course_home/course_metadata/course-v1:CUCWD+FAA-ACS-AM-ID-FLF+DOCUMENTATION?browser_timezone=America%2FNew_York

## Invoking Management Command

**WARNING**
We added in a --limit-bulk-update-operation {0-N} command option to prevent the command from consuming all server memory and crashing the server. The default number of courses is set to 150. Please make sure that you pay attention to your server resources before running this command in bulk.

The user passed needs to have superuser rights.

```
# Single Course
# Set the following advanced settings:
# `invitation_only` to `true`
# `catalog_visilibilty` to `about`
python manage.py cms --settings=devstack_docker set_advanced_fields_all_courses \
--fields_json '{"invitation_only": {"value": "true"}}' --user edx@example.com --course course-v1:ORG+COURSENUMBER+COURSERUN --force-update-catalog-visibility-about

# All Courses
# Set the following advanced settings:
# `invitation_only` to `true`
# `catalog_visilibilty` to `about`
# `cerfificate_display_behavior` to `early_no_info`
python manage.py cms --settings=devstack_docker set_advanced_fields_all_courses \
--fields_json '{"invitation_only": {"value": "true"}, "certificates_display_behavior": {"value": "early_no_info"}}' --user edx@example.com --course course-v1:ORG+COURSENUMBER+COURSERUN --force-update-catalog-visibility-about

# All Courses
# Set the following advanced settings:
# `catalog_visilibilty` to `about`
python manage.py cms --settings=devstack_docker set_advanced_fields_all_courses \
--fields_json '{}' --user edx@example.com --course course-v1:ORG+COURSENUMBER+COURSERUN --force-update-catalog-visibility-about
```