### PR TITLE
Disable `Badges` and `Glossary` courseware tabs by default.

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_tabs.py
+++ b/cms/djangoapps/contentstore/views/tests/test_tabs.py
@@ -203,7 +203,7 @@ class PrimitiveTabEdit(ModuleStoreTestCase):
         with self.assertRaises(ValueError):
             tabs.primitive_delete(course, 1)
         with self.assertRaises(IndexError):
-            tabs.primitive_delete(course, 7)
+            tabs.primitive_delete(course, 8)  # Increased this to accommodate the Badges Tab by default
         tabs.primitive_delete(course, 2)
         self.assertNotIn({'type': 'textbooks'}, course.tabs)
         # Check that discussion has shifted up

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -602,7 +602,7 @@ class CourseFields:  # lint-amnesty, pylint: disable=missing-class-docstring
             "Issue Open Badges badges for this course. Badges are generated when certificates are created."
         ),
         scope=Scope.settings,
-        default=True
+        default=False
     )
     ## Course level Certificate Name overrides.
     cert_name_short = String(

--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -405,6 +405,7 @@ class CourseTabList(List):
             discussion_tab,
             CourseTab.load('wiki'),
             CourseTab.load('progress'),
+            CourseTab.load('badges_progress'),
             CourseTab.load('glossary'),
         ])
 

--- a/lms/djangoapps/badges/tests/test_models.py
+++ b/lms/djangoapps/badges/tests/test_models.py
@@ -126,7 +126,7 @@ class BadgeClassTest(ModuleStoreTestCase):
         """
         Verify that the course_id is used in fetching existing badges or creating new ones.
         """
-        course_key = CourseFactory.create().location.course_key
+        course_key = CourseFactory.create(metadata={'issue_badges': True}).location.course_key
         premade_badge_class = BadgeClassFactory.create(course_id=course_key)
         badge_class = BadgeClass.get_badge_class(
             slug='test_slug', issuing_component='test_component', description='Attempted override',
@@ -270,7 +270,7 @@ class BadgeAssertionTest(ModuleStoreTestCase):
         """
         user = UserFactory()
         assertions = [BadgeAssertionFactory.create(user=user).id for _i in range(3)]
-        course = CourseFactory.create()
+        course = CourseFactory.create(metadata={'issue_badges': True})
         course_key = course.location.course_key
         course_badges = [RandomBadgeClassFactory(course_id=course_key) for _i in range(3)]
         course_assertions = [

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -83,7 +83,8 @@ class CommonCertificatesTestCase(ModuleStoreTestCase):
             number='run1',
             display_name='refundable course',
             certificate_available_date=datetime.datetime.today() - datetime.timedelta(days=1),
-            certificates_display_behavior=CertificatesDisplayBehaviors.END_WITH_DATE
+            certificates_display_behavior=CertificatesDisplayBehaviors.END_WITH_DATE,
+            issue_badges=True
         )
         self.course_id = self.course.location.course_key
         self.user = UserFactory.create(
@@ -1072,7 +1073,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         """
         mock_get_course_run_details.return_value = self.mock_course_run_details
         othercourse = CourseFactory.create(
-            org='cstX', number='cst_22', display_name='custom template course'
+            org='cstX', number='cst_22', display_name='custom template course', issue_badges=True
         )
 
         self._add_course_certificates(count=1, signatory_count=2)

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -63,7 +63,7 @@ class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase, Cache
     }
 
     COURSE_OVERVIEW_TABS = {
-        'courseware', 'info', 'textbooks', 'discussion', 'wiki', 'progress', 'glossary'
+        'courseware', 'info', 'textbooks', 'discussion', 'wiki', 'progress', 'badges_progress', 'glossary'
     }
 
     ENABLED_SIGNALS = ['course_deleted', 'course_published']

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -1091,3 +1091,5 @@ yarl==1.7.0
     # via -r ./requirements/edx/private.txt
 # -e git+https://github.com/CUCWD/xblock-qualtrics-survey.git@release/v.2.1.0-maple.3-cucwd#egg=xblock_qualtrics_survey==2.1.0
     # via -r ./requirements/edx/private.txt
+# -e git+https://github.com/CUCWD/edx-ora2.git@3.7.2-maple.3-cucwd#egg=ora2==3.7.2
+    # via -r ./requirements/edx/private.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1581,3 +1581,5 @@ zipp==3.6.0
     # via -r ./requirements/edx/private.txt
 -e git+https://github.com/CUCWD/xblock-qualtrics-survey.git@release/v.2.1.0-maple.3-cucwd#egg=xblock_qualtrics_survey==2.1.0
     # via -r ./requirements/edx/private.txt
+-e git+https://github.com/CUCWD/edx-ora2.git@3.7.2-maple.3-cucwd#egg=ora2==3.7.2
+    # via -r ./requirements/edx/private.txt

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
     entry_points={
         "openedx.course_tab": [
             "badges_progress = lms.djangoapps.courseware.tabs:BadgesTab",
-            "course_badges = lms.djangoapps.courseware.tabs:BadgesTab",
             "ccx = lms.djangoapps.ccx.plugins:CcxCourseTab",
             "courseware = lms.djangoapps.courseware.tabs:CoursewareTab",
             "course_info = lms.djangoapps.courseware.tabs:CourseInfoTab",


### PR DESCRIPTION
These tabs need to be enabled when additional configuration is setup and not every course will use these tabs by default.