### PR TITLE
Upgrading script to Google Analytics 4 (gtag.js).

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -23,6 +23,7 @@ from django.utils.translation import get_language_bidi
 from lms.djangoapps.courseware.access import has_access
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
+from openedx.core.djangolib.markup import strip_all_tags_but_br
 from openedx.core.release import RELEASE_LINE
 from common.djangoapps.pipeline_mako import render_require_js_path_overrides
 
@@ -151,13 +152,15 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
 <% ga_acct = static.get_value("GOOGLE_ANALYTICS_ACCOUNT", settings.GOOGLE_ANALYTICS_ACCOUNT) %>
 % if ga_acct:
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=${ga_acct | n, js_escaped_string}"></script>
-    <script  type="text/javascript">
+    <script type="text/javascript" async src="https://www.googletagmanager.com/gtag/js?id=${ga_acct | n, strip_all_tags_but_br}"></script>
+    <script type="text/javascript">
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', '${ga_acct | n, js_escaped_string}');
+      gtag('config', '${ga_acct | n, js_escaped_string}', {
+        cookie_flags: 'max-age=7200;secure;samesite=none'
+      });
     </script>
 % endif
 

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -150,16 +150,14 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
 
 <% ga_acct = static.get_value("GOOGLE_ANALYTICS_ACCOUNT", settings.GOOGLE_ANALYTICS_ACCOUNT) %>
 % if ga_acct:
-    <script type="text/javascript">
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', '${ga_acct | n, js_escaped_string}']);
-    _gaq.push(['_trackPageview']);
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=${ga_acct | n, js_escaped_string}"></script>
+    <script  type="text/javascript">
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-    (function() {
-      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-    })();
+      gtag('config', '${ga_acct | n, js_escaped_string}');
     </script>
 % endif
 


### PR DESCRIPTION
Because Google analytics tracking is migrating to GA4 this summer, we're updating our Universal Analytics to this new format.

Also we're settings the `SameSite` for third-party sites (e.g. Canvas, Blackboard) so the Google cookies won't be blocked when accessing EducateWorkforce content.