### PR TITLE
Hide footer about Open edX.

### DIFF
--- a/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/lms/static/sass/partials/lms/theme/_extras.scss
@@ -5,3 +5,15 @@
 // to add any custom rules that you need. You can also import
 // partials directly into this file so that you can break your
 // rules into modular pieces.
+
+/////////////////// Footer
+.wrapper-footer {
+    
+    footer#footer-openedx .footer-about-openedx {
+  
+        // Hide this for now since CUCWD doesn't want to show that we run Open edX.
+        display: none !important;
+  
+    }
+  }
+  


### PR DESCRIPTION
Seems like the override performed by site themes is not overriding this file so we're handling this here across all sites.