### PR TITLE
Move Qualtrics API configuration to separate organization list.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2329,24 +2329,11 @@ BULK_EMAIL_LOG_SENT_EMAILS = False
 DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 
 #################### Qualtrics Settings #######################
-QUALTRICS_API_BASE_URL = None
-QUALTRICS_BACKEND = 'qualtrics.backends.qualtrics.qualtricsBackend'
+# QUALTRICS_BACKEND = 'qualtrics.backends.qualtrics.qualtricsBackend'
 QUALTRICS_API_VERSION = "v3"
 QUALTRICS_API_TOKEN_EXPIRATION = 3599  # 1 hr
 QUALTRICS_API_TOKEN_CACHE = 'qualtrics_api_token_cache'
-QUALTRICS_SCORE_ID = None
-
-# OAuth2 Authentication (Client Credentials)
-# https://api.qualtrics.com/instructions/docs/Instructions/oauth-authentication.md
-# Client credentials grant type doesn't use `refresh` token for access.
-QUALTRICS_API_CLIENT_ID = None
-QUALTRICS_API_CLIENT_SECRET = None
-
-# API Token Authentication
-# https://api.qualtrics.com/instructions/docs/Instructions/api-key-authentication.md
-# Recommend OAuth2 Authentication to limit scope of API calls.
-# This is automatically switch over to OAuth2 after API v1.
-QUALTRICS_API_TOKEN = None
+QUALTRICS_ORGANIZATION_API_CONFIGS = []
 
 ###################### Grade Downloads ######################
 # These keys are used for all of our asynchronous downloadable files, including

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3606,24 +3606,11 @@ BIGCOMMERCE_APP_STORE_HASH = None
 BIGCOMMERCE_APP_STORE_URL = None
 
 #################### Qualtrics Settings #######################
-QUALTRICS_API_BASE_URL = None
-QUALTRICS_BACKEND = 'qualtrics.backends.qualtrics.qualtricsBackend'
+# QUALTRICS_BACKEND = 'qualtrics.backends.qualtrics.qualtricsBackend'
 QUALTRICS_API_VERSION = "v3"
 QUALTRICS_API_TOKEN_EXPIRATION = 3599  # 1 hr
 QUALTRICS_API_TOKEN_CACHE = 'qualtrics_api_token_cache'
-QUALTRICS_SCORE_ID = None
-
-# OAuth2 Authentication (Client Credentials)
-# https://api.qualtrics.com/instructions/docs/Instructions/oauth-authentication.md
-# Client credentials grant type doesn't use `refresh` token for access.
-QUALTRICS_API_CLIENT_ID = None
-QUALTRICS_API_CLIENT_SECRET = None
-
-# API Token Authentication
-# https://api.qualtrics.com/instructions/docs/Instructions/api-key-authentication.md
-# Recommend OAuth2 Authentication to limit scope of API calls.
-# This is automatically switch over to OAuth2 after API v1.
-QUALTRICS_API_TOKEN = None
+QUALTRICS_ORGANIZATION_API_CONFIGS = []
 
 ###################### Grade Downloads ######################
 # These keys are used for all of our asynchronous downloadable files, including


### PR DESCRIPTION
In order to make sure that we can connect to multiple Qualtrics organizations were defining a list that will house all the configuration settings.