### PR TITLE
Ignore `Tutor` release changes during initial provisioning.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,10 @@ dist
 
 # Locally generated PII reports
 pii_report
+
+### Tutor configuration
+lms/envs/tutor/
+lms/static/js/i18n/
+cms/envs/tutor/
+cms/static/js/i18n/
+results.txt


### PR DESCRIPTION
Applied .gitignore changes for Tutor provisioning install. This will ignore Tutor specific changes for this repo.