### PR TITLE
Make sure that students with external LMS role `Learner` get enrolled in platform course.

### DIFF
--- a/lms/djangoapps/lti_provider/users.py
+++ b/lms/djangoapps/lti_provider/users.py
@@ -4,6 +4,7 @@ that an individual has in the campus LMS platform and on edX.
 """
 
 
+import logging
 import random
 import string
 import uuid
@@ -17,6 +18,8 @@ from django.db import IntegrityError, transaction
 from common.djangoapps.student.models import UserProfile
 from lms.djangoapps.lti_provider.models import LtiUser
 
+log = logging.getLogger("edx.lti_provider")
+
 
 def authenticate_lti_user(request, lti_user_id, lti_consumer):
     """
@@ -27,6 +30,7 @@ def authenticate_lti_user(request, lti_user_id, lti_consumer):
     If the currently logged-in user does not match the user specified by the LTI
     launch, log out the old user and log in the LTI identity.
     """
+    log.info("authenticate_lti_user %s %s %s", request, lti_user_id, lti_consumer)
     try:
         lti_user = LtiUser.objects.get(
             lti_user_id=lti_user_id,
@@ -35,6 +39,10 @@ def authenticate_lti_user(request, lti_user_id, lti_consumer):
     except LtiUser.DoesNotExist:
         # This is the first time that the user has been here. Create an account.
         lti_user = create_lti_user(lti_user_id, lti_consumer)
+        log.info(
+            "authenticate_lti_user %s",
+            lti_user
+        )
 
     if not (request.user.is_authenticated and
             request.user == lti_user.edx_user):
@@ -91,6 +99,12 @@ def switch_user(request, lti_user, lti_consumer):
         lti_user_id=lti_user.lti_user_id,
         lti_consumer=lti_consumer
     )
+    log.info(
+        "switch_user lti_user %s, lti_consumer %s, edx-user %s",
+        lti_user,
+        lti_consumer,
+        edx_user
+    )
     if not edx_user:
         # This shouldn't happen, since we've created edX accounts for any LTI
         # users by this point, but just in case we can return a 403.
@@ -128,6 +142,12 @@ class LtiBackend:
         If such a user is not found, the method returns None (in line with the
         authentication backend specification).
         """
+        log.info(
+            "LtiBackend.authenticate username %s, lti_user_id %s, lti_consumer %s",
+            username,
+            lti_user_id,
+            lti_consumer
+        )
         try:
             edx_user = User.objects.get(username=username)
         except User.DoesNotExist:


### PR DESCRIPTION
Added log statements when user is authenticated with the platform during the `lti_launch` function.

**Learner Course Enrollment**
In order to count unique students for our own analytic purposes, we're make sure that these anonymous LTI users get enrolled in the course. We're also assuming that the `course_mode` is set to `honor` mode because most of our courses offer certificates of completion.

The functionality that edX provides ignores this course enrollment.

**Special Instructions For `Instructor` Roles**
In order to make sure the the instructor has full access rights to EducateWorkforce Instructor Dashboard and analytic tools we'd still want to register their platform accounts with `Instructor/Staff` roles.

To prevent duplicate instructor accounts, we follow these steps to ensure uniqueness:
- Register instructors directly in EducateWorkforce course as we have been doing with the Instructor/Staff role.
- Only perform course enrollments for students in the Canvas course. They'll come in anonymously to the platform but they'll be enrolled the first time they launch the lti_provider link.
- Should an instructor be registered on Canvas directly and not EducateWorkforce, then that account will come in anonymously to EducateWorkforce, but it won't count towards our unique students/instructor count because we're not calling the `CourseEnrollment.enroll()` method.
