### PR TITLE
Applied `django-require` package updates needed to successfully build the `openedx` Docker image for `nutmeg`.

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -174,5 +174,4 @@ xblock-utils                        # Provides utilities used by the Discussion 
 xss-utils                           # https://github.com/edx/edx-platform/pull/20633 Fix XSS via Translations
 enmerkar-underscore                 # Implements a underscore extractor for django-babel.
 xblock-drag-and-drop-v2             # Drag and Drop XBlock
-
--r private.txt            # Include our EducateWorkforce specific packages
+openedx-django-require

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -339,8 +339,6 @@ django-pyfs==3.2.0
     # via -r requirements/edx/base.in
 django-ratelimit==3.0.1
     # via -r requirements/edx/base.in
-django-require @ git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776
-    # via -r requirements/edx/github.in
 django-sekizai==3.0.1
     # via
     #   -r requirements/edx/base.in
@@ -736,6 +734,8 @@ oauthlib==3.0.1
     #   requests-oauthlib
     #   social-auth-core
 openedx-calc==3.0.1
+    # via -r requirements/edx/base.in
+openedx-django-require==2.1.0
     # via -r requirements/edx/base.in
 openedx-events==0.8.1
     # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -440,8 +440,6 @@ django-pyfs==3.2.0
     # via -r requirements/edx/testing.txt
 django-ratelimit==3.0.1
     # via -r requirements/edx/testing.txt
-django-require @ git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776
-    # via -r requirements/edx/testing.txt
 django-sekizai==3.0.1
     # via
     #   -r requirements/edx/testing.txt
@@ -978,6 +976,8 @@ oauthlib==3.0.1
     #   requests-oauthlib
     #   social-auth-core
 openedx-calc==3.0.1
+    # via -r requirements/edx/testing.txt
+openedx-django-require==2.1.0
     # via -r requirements/edx/testing.txt
 openedx-events==0.8.1
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -59,9 +59,6 @@
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 
-# original repo is not maintained any more.
-git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
-
 # Our libraries:
 -e git+https://github.com/openedx/blockstore.git@1.2.1#egg=blockstore==1.2.1
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -423,8 +423,6 @@ django-pyfs==3.2.0
     # via -r requirements/edx/base.txt
 django-ratelimit==3.0.1
     # via -r requirements/edx/base.txt
-django-require @ git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776
-    # via -r requirements/edx/base.txt
 django-sekizai==3.0.1
     # via
     #   -r requirements/edx/base.txt
@@ -922,6 +920,8 @@ oauthlib==3.0.1
     #   requests-oauthlib
     #   social-auth-core
 openedx-calc==3.0.1
+    # via -r requirements/edx/base.txt
+openedx-django-require==2.1.0
     # via -r requirements/edx/base.txt
 openedx-events==0.8.1
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
The original referenced repo https://github.com/edx/django-require?tab=readme-ov-file has been deprecated and moved to the `openedx` organization on Github.

Details concerning why we merge this commit are here.
https://discuss.openedx.org/t/please-update-your-git-urls-for-edx-platform-and-several-other-repos/12387

The tutor recommended patch updates for this did not work when we went to build out the `openedx` image. I was still receiving this git fetch error when pulling down the django-require repo even after the patch updates recommended by the community below.

![image](https://github.com/CUCWD/edx-platform/assets/5641338/2f854a41-5ec2-413c-8e2d-5ef081d88a17)
 
```
Moving this to the openedx-dockerfile-post-python-requirements patch as well because it comes after the ./requirements/edx/base.txt call.

hooks.Filters.ENV_PATCHES.add_items([
   (
       "openedx-dockerfile-git-patches-default",
       """
# Fixing this `django-require` package to be from `openedx` org rather than `edx` org.
RUN git config url."https://github.com/openedx/django-require.git".insteadOf "https://github.com/edx/django-require.git"
"""
   ),
   (
       "openedx-dockerfile-post-python-requirements",
       """
# Make sure to install latest version of `openedx/django-require` for the platform to use. Uninstall existing version 1.0.12 first, then reinstall v2.0.0.
RUN pip uninstall -y django-require
RUN pip install -e git+https://github.com/openedx/django-require.git@v2.0.0#egg=openedx-django-require==2.0.0
    ),
    ...
])

```
