### PR TITLE
Applied `django-require` package updates needed to successfully build the `openedx` Docker image for `maple`.

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -165,5 +165,6 @@ XBlock                              # Courseware component architecture
 xblock-utils                        # Provides utilities used by the Discussion XBlock
 xss-utils                           # https://github.com/edx/edx-platform/pull/20633 Fix XSS via Translations
 enmerkar-underscore                 # Implements a underscore extractor for django-babel.
+openedx-django-require
 
 # -r private.txt            # Include our EducateWorkforce specific packages

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -316,8 +316,6 @@ django-ratelimit==3.0.1
     # via -r requirements/edx/base.in
 django-ratelimit-backend @ git+https://github.com/edx/django-ratelimit-backend.git@6e1a0c6ea1d27062c16e9fb94d3c44475146877e
     # via -r requirements/edx/github.in
-django-require @ git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776
-    # via -r requirements/edx/github.in
 django-sekizai==2.0.0
     # via
     #   -r requirements/edx/base.in
@@ -683,6 +681,8 @@ oauthlib==3.0.1
     #   requests-oauthlib
     #   social-auth-core
 openedx-calc==2.0.1
+    # via -r requirements/edx/base.in
+openedx-django-require==2.1.0
     # via -r requirements/edx/base.in
 openedx-events==0.6.0
     # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -409,8 +409,6 @@ django-ratelimit==3.0.1
     # via -r requirements/edx/testing.txt
 django-ratelimit-backend @ git+https://github.com/edx/django-ratelimit-backend.git@6e1a0c6ea1d27062c16e9fb94d3c44475146877e
     # via -r requirements/edx/testing.txt
-django-require @ git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776
-    # via -r requirements/edx/testing.txt
 django-sekizai==2.0.0
     # via
     #   -r requirements/edx/testing.txt
@@ -916,6 +914,8 @@ oauthlib==3.0.1
     #   requests-oauthlib
     #   social-auth-core
 openedx-calc==2.0.1
+    # via -r requirements/edx/testing.txt
+openedx-django-require==2.1.0
     # via -r requirements/edx/testing.txt
 openedx-events==0.6.0
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -63,9 +63,6 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 # back into the upstream code.
 git+https://github.com/edx/django-ratelimit-backend.git@6e1a0c6ea1d27062c16e9fb94d3c44475146877e#egg=django-ratelimit-backend
 
-# original repo is not maintained any more.
-git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776#egg=django-require==1.0.12
-
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -393,8 +393,6 @@ django-ratelimit==3.0.1
     # via -r requirements/edx/base.txt
 django-ratelimit-backend @ git+https://github.com/edx/django-ratelimit-backend.git@6e1a0c6ea1d27062c16e9fb94d3c44475146877e
     # via -r requirements/edx/base.txt
-django-require @ git+https://github.com/edx/django-require.git@0c54adb167142383b26ea6b3edecc3211822a776
-    # via -r requirements/edx/base.txt
 django-sekizai==2.0.0
     # via
     #   -r requirements/edx/base.txt
@@ -864,6 +862,8 @@ oauthlib==3.0.1
     #   requests-oauthlib
     #   social-auth-core
 openedx-calc==2.0.1
+    # via -r requirements/edx/base.txt
+openedx-django-require==2.1.0
     # via -r requirements/edx/base.txt
 openedx-events==0.6.0
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
The original referenced repo https://github.com/edx/django-require?tab=readme-ov-file has been deprecated and moved to the `openedx` organization on Github.

Details concerning why we merge this commit are here.
https://discuss.openedx.org/t/please-update-your-git-urls-for-edx-platform-and-several-other-repos/12387

The tutor recommended patch updates for this did not work when we went to build out the `openedx` image. I was still receiving this git fetch error when pulling down the django-require repo even after the patch updates recommended by the community below.

![image](https://github.com/CUCWD/edx-platform/assets/5641338/2f854a41-5ec2-413c-8e2d-5ef081d88a17)
 
```
Moving this to the openedx-dockerfile-post-python-requirements patch as well because it comes after the ./requirements/edx/base.txt call.

hooks.Filters.ENV_PATCHES.add_items([
   (
       "openedx-dockerfile-git-patches-default",
       """
# Fixing this `django-require` package to be from `openedx` org rather than `edx` org.
RUN git config url."https://github.com/openedx/django-require.git".insteadOf "https://github.com/edx/django-require.git"
"""
   ),
   (
       "openedx-dockerfile-post-python-requirements",
       """
# Make sure to install latest version of `openedx/django-require` for the platform to use. Uninstall existing version 1.0.12 first, then reinstall v2.0.0.
RUN pip uninstall -y django-require
RUN pip install -e git+https://github.com/openedx/django-require.git@v2.0.0#egg=openedx-django-require==2.0.0
    ),
    ...
])

```
