### PR TITLE
Remove course outline question count and estimates by default for nutmeg release.

### DIFF
--- a/lms/djangoapps/course_home_api/outline/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/serializers.py
@@ -30,7 +30,7 @@ class CourseBlockSerializer(serializers.Serializer):
         scored = block.get('scored')
 
         if (settings.FEATURES.get('ENABLE_COURSEWARE_OUTLINE_QUESTION_COUNT') and
-            num_graded_problems and block_type == 'sequential'):
+                num_graded_problems and block_type == 'sequential'):
             questions = ngettext('({number} Question)', '({number} Questions)', num_graded_problems)
             display_name += ' ' + questions.format(number=num_graded_problems)
 

--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -279,6 +279,8 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert exam_data['due'] is not None
         assert exam_data['icon'] == 'fa-foo-bar'
 
+    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSEWARE_OUTLINE_QUESTION_COUNT': True})
+    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSEWARE_OUTLINE_EFFORT_ESTIMATES': True})
     def test_assignment(self):
         course = CourseFactory.create()
         with self.store.bulk_operations(course.id):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -518,6 +518,12 @@ FEATURES = {
     # .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1320
     'ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER': False,
 
+    # Enable courseware outline question count
+    'ENABLE_COURSEWARE_OUTLINE_QUESTION_COUNT': False,
+
+    # Enable courseware outline effort estimates
+    'ENABLE_COURSEWARE_OUTLINE_EFFORT_ESTIMATES': False,
+
     # Enable organizational email opt-in
     'ENABLE_MKTG_EMAIL_OPT_IN': False,
 


### PR DESCRIPTION
We are temporarily disabling the course outline question count and estimate values by default until we can ensure that the values are correct.

The question count is off with Qualtrics XBlock indicating 1 Question when it has 10 Questions. We'll need to update the XBlock to return the number of questions on the Qualtrics survey.

The estimate metrics are off because we need to account for most course components. Also, we're improving the estimate values with our own override estimate calculations.
