### PR TITLE
Remove course outline question count and estimates by default for maple release.

### DIFF
--- a/lms/djangoapps/course_home_api/outline/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/serializers.py
@@ -30,7 +30,7 @@ class CourseBlockSerializer(serializers.Serializer):
         scored = block.get('scored')
 
         if (settings.FEATURES.get('ENABLE_COURSEWARE_OUTLINE_QUESTION_COUNT') and
-            num_graded_problems and block_type == 'sequential'):
+                num_graded_problems and block_type == 'sequential'):
             questions = ngettext('({number} Question)', '({number} Questions)', num_graded_problems)
             display_name += ' ' + questions.format(number=num_graded_problems)
 

--- a/lms/djangoapps/course_home_api/outline/tests/test_view.py
+++ b/lms/djangoapps/course_home_api/outline/tests/test_view.py
@@ -312,6 +312,8 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         assert exam_data['due'] is not None
         assert exam_data['icon'] == 'fa-foo-bar'
 
+    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSEWARE_OUTLINE_QUESTION_COUNT': True})
+    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSEWARE_OUTLINE_EFFORT_ESTIMATES': True})
     def test_assignment(self):
         course = CourseFactory.create()
         with self.store.bulk_operations(course.id):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -518,6 +518,12 @@ FEATURES = {
     # .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1320
     'ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER': False,
 
+    # Enable courseware outline question count
+    'ENABLE_COURSEWARE_OUTLINE_QUESTION_COUNT': False,
+
+    # Enable courseware outline effort estimates
+    'ENABLE_COURSEWARE_OUTLINE_EFFORT_ESTIMATES': False,
+
     # Enable organizational email opt-in
     'ENABLE_MKTG_EMAIL_OPT_IN': False,
 

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -123,7 +123,12 @@ openedx-events                      # Open edX Events from Hooks Extension Frame
 ora2
 piexif                              # Exif image metadata manipulation, used in the profile_images app
 Pillow                              # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.
-py2neo                              # Driver for converting Python modulestore structures to Neo4j's schema (for Coursegraph).
+
+# Driver for converting Python modulestore structures to Neo4j's schema (for Coursegraph).
+# Using the fork because official package has been removed from PyPI/GitHub
+# Follow up issue to remove this fork: https://github.com/openedx/edx-platform/issues/33456
+https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
+
 pycountry
 pycryptodomex
 pygments                            # Used to support colors in paver command output

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -725,7 +725,7 @@ psutil==5.8.0
     # via
     #   -r requirements/edx/paver.txt
     #   edx-django-utils
-py2neo==2021.2.3
+py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -993,7 +993,7 @@ py==1.10.0
     #   pytest
     #   pytest-forked
     #   tox
-py2neo==2021.2.3
+py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -928,11 +928,8 @@ psutil==5.8.0
     #   pact-python
     #   pytest-xdist
 py==1.10.0
-    # via
-    #   pytest
-    #   pytest-forked
-    #   tox
-py2neo==2021.2.3
+    # via tox
+py2neo @ https://github.com/overhangio/py2neo/releases/download/2021.2.3/py2neo-2021.2.3.tar.gz
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt


### PR DESCRIPTION
We are temporarily disabling the course outline question count and estimate values by default until we can ensure that the values are correct.

The question count is off with Qualtrics XBlock indicating 1 Question when it has 10 Questions. We'll need to update the XBlock to return the number of questions on the Qualtrics survey.

The estimate metrics are off because we need to account for most course components. Also, we're improving the estimate values with our own override estimate calculations.
