### PR TITLE
Github actions artifact v4 upgrade.

### DIFF
--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -27,8 +27,9 @@ runs:
 
     - name: save pytest warnings json file
       if: success()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: pytest-warnings-json
         path: |
           test_root/log/pytest_warnings*.json
+        overwrite: true

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -73,7 +73,7 @@ jobs:
         xvfb-run --auto-servernum ./scripts/all-tests.sh
 
     - name: Save Job Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Build-Artifacts
         path: |
@@ -81,3 +81,4 @@ jobs:
           test_root/log/*.png
           test_root/log/*.log
           **/TEST-*.xml
+        overwrite: true

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -71,10 +71,11 @@ jobs:
 
     - name: Save Job Artifacts
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Build-Artifacts
         path: |
           **/reports/**/*
           test_root/log/**/*.log
           *.log
+        overwrite: true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -83,7 +83,7 @@ jobs:
         run: sudo chown runner:runner -R .*
       - uses: actions/checkout@v2
       - name: collect pytest warnings files
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: pytest-warnings-json
           path: test_root/log
@@ -97,8 +97,9 @@ jobs:
 
       - name: save warning report
         if: success()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-warning-report-html
           path: |
             reports/pytest_warnings/warning_report_all.html
+          overwrite: true


### PR DESCRIPTION
V1 and V2 of Github artifact actions was deprecated. Upgraded to V4 latest version.

https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
