### PR TITLE
Provide better UX for the learner for these pre/post-program surveys.

### DIFF
--- a/lms/templates/dashboard/_dashboard_program_surveys.html
+++ b/lms/templates/dashboard/_dashboard_program_surveys.html
@@ -63,7 +63,7 @@ for enrollment in course_enrollments:
 
     <div class="program-survey">
         <h2 class="program-survey-header">
-            Aviation Mechanic General
+            Aviation Mechanic General Surveys
         </h2>
         <div class="program-details">
             <p>This program of courses equips learners for entry into the FAA mechanic pathway. Upon completion, they gain foundational knowledge in mathematics, aircraft drawings, weight and balance, aircraft materials, processes and tools, physics, electricity, inspection, ground operations, and FAA regulations governing maintenance technician certification and work.</p>
@@ -71,19 +71,19 @@ for enrollment in course_enrollments:
 
         <div class="survey-details-wrapper">
             <div class="survey-wrapper">
-                <h2 class="survey-title">Pre-Program Survey</h2>
+                <h2 class="survey-title">Pre-Program</h2>
                 <hr>
-                <p class="survey-instructions">Answer this survey prior to taking any course content</p>
+                <p class="survey-instructions">New Learner: Take this survey upon program entry.</p>
                 <p class="survey-details">This will help us understand your career awareness and interest, gauge where you are with FAA General maintenance knowledge and skill confidence, career plans, and demographic information.</p>
                 <a class="provide-feedback-btn" href="https://clemson.qualtrics.com/jfe/form/SV_3C2RY5TuB0uIZ70?${username_string}&${platform_fullname}&${user_email_string}&${platform_anonymous_user_id_string}&${org_institution_name_string}&${org_institution_shortname_string}&${org_institution_city_string}&${org_institution_state_string}&${org_institution_zipcode_string}&${demographic_zipcode}&${demographic_country}&${program_name}" target="_blank">
-                    Provide Feedback</a>
+                    Provide Input</a>
             </div>
 
             <div class="survey-wrapper">
-                <h2 class="survey-title">Post-Program Survey</h2>
+                <h2 class="survey-title">Post-Program</h2>
                 <hr>
-                <p class="survey-instructions">Answer this survey after you have completed most of this program's courses</p>
-                <p class="survey-details">This will help us understand your completion of FAA General maintenance program, career awareness and interest, kwowledge and skill confidence, and demographic information.</p>
+                <p class="survey-instructions">Continuing Learner: Take this survey upon program exit.</p>
+                <p class="survey-details">This will help us understand your completion of FAA General maintenance program, career awareness and interest, knowledge and skill confidence, and demographic information.</p>
                 <a class="provide-feedback-btn" href="https://clemson.qualtrics.com/jfe/form/SV_1Al5SpJgWVv6bFI?${username_string}&${platform_fullname}&${user_email_string}&${platform_anonymous_user_id_string}&${org_institution_name_string}&${org_institution_shortname_string}&${org_institution_city_string}&${org_institution_state_string}&${org_institution_zipcode_string}&${demographic_zipcode}&${demographic_country}&${program_name}" target="_blank">
                 Provide Feedback</a>
             </div>


### PR DESCRIPTION
I spoke with Austin Sanderson about this verbiage and we came up with these changes.

Updated UX text changes applied.

![image](https://github.com/user-attachments/assets/b85006a9-33e4-431b-bf68-07640ecec222)
